### PR TITLE
Feat: Alterado retorno da biblioteca para suportar Promise

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,10 +16,7 @@
       },
       "extends": [
         "eslint:recommended",
-        "plugin:@typescript-eslint/recommended",
-        "plugin:@angular-eslint/recommended",
-        "plugin:@typescript-eslint/recommended-requiring-type-checking",
-        "plugin:@angular-eslint/template/process-inline-templates"
+        "plugin:@typescript-eslint/recommended"
       ],
       "rules": {
         "indent": [
@@ -50,22 +47,6 @@
           "error",
           {
             "ignoreStatic": true
-          }
-        ],
-        "@angular-eslint/component-selector": [
-          "error",
-          {
-            "prefix": "app",
-            "style": "kebab-case",
-            "type": "element"
-          }
-        ],
-        "@angular-eslint/directive-selector": [
-          "error",
-          {
-            "prefix": "app",
-            "style": "camelCase",
-            "type": "attribute"
           }
         ]
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "6.1.0",
       "license": "MIT",
       "dependencies": {
+        "clonedeep": "^2.0.0",
         "json.date-extensions": "^1.2.2",
         "tslib": "^2.0.0",
         "uuid": "^9.0.0"
@@ -29,7 +30,6 @@
         "@angular/language-service": "^15.2.9",
         "@types/jasmine": "~3.6.0",
         "@types/jasminewd2": "~2.0.3",
-        "@types/lodash-es": "^4.17.6",
         "@types/node": "^12.11.1",
         "@typescript-eslint/eslint-plugin": "^5.46.1",
         "@typescript-eslint/parser": "^5.46.1",
@@ -3811,23 +3811,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/lodash": {
-      "version": "4.14.191",
-      "resolved": "https://npm.totvs.io/@types%2flodash/-/lodash-4.14.191.tgz",
-      "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/lodash-es": {
-      "version": "4.17.6",
-      "resolved": "https://npm.totvs.io/@types%2flodash-es/-/lodash-es-4.17.6.tgz",
-      "integrity": "sha512-R+zTeVUKDdfoRxpAryaQNRKk3105Rrgx2CFRClIgRGaqDTdjsm8h6IYA8ir584W3ePzkZfst5xIgDwYrlh9HLg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/lodash": "*"
-      }
-    },
     "node_modules/@types/mime": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
@@ -5486,6 +5469,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/clonedeep": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/clonedeep/-/clonedeep-2.0.0.tgz",
+      "integrity": "sha512-dbSwE7z2tJhF3511dzWqyKOKRA+5uQaILERDdQPxe/Eihm3atnkJRaz/t32fQqfmPBdJiICZD9iLSbaT47UbLw=="
     },
     "node_modules/color-convert": {
       "version": "1.9.3",
@@ -16918,21 +16906,6 @@
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
     },
-    "@types/lodash": {
-      "version": "4.14.191",
-      "resolved": "https://npm.totvs.io/@types%2flodash/-/lodash-4.14.191.tgz",
-      "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==",
-      "dev": true
-    },
-    "@types/lodash-es": {
-      "version": "4.17.6",
-      "resolved": "https://npm.totvs.io/@types%2flodash-es/-/lodash-es-4.17.6.tgz",
-      "integrity": "sha512-R+zTeVUKDdfoRxpAryaQNRKk3105Rrgx2CFRClIgRGaqDTdjsm8h6IYA8ir584W3ePzkZfst5xIgDwYrlh9HLg==",
-      "dev": true,
-      "requires": {
-        "@types/lodash": "*"
-      }
-    },
     "@types/mime": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
@@ -18081,6 +18054,11 @@
         "kind-of": "^6.0.2",
         "shallow-clone": "^3.0.0"
       }
+    },
+    "clonedeep": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/clonedeep/-/clonedeep-2.0.0.tgz",
+      "integrity": "sha512-dbSwE7z2tJhF3511dzWqyKOKRA+5uQaILERDdQPxe/Eihm3atnkJRaz/t32fQqfmPBdJiICZD9iLSbaT47UbLw=="
     },
     "color-convert": {
       "version": "1.9.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,31 +1,17 @@
 {
   "name": "web-backend-api",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "web-backend-api",
-      "version": "6.0.0",
+      "version": "6.1.0",
       "license": "MIT",
       "dependencies": {
-        "@angular/animations": "15.2.9",
-        "@angular/common": "15.2.9",
-        "@angular/compiler": "15.2.9",
-        "@angular/core": "15.2.9",
-        "@angular/forms": "15.2.9",
-        "@angular/localize": "^15.2.9",
-        "@angular/platform-browser": "15.2.9",
-        "@angular/platform-browser-dynamic": "15.2.9",
-        "@angular/router": "15.2.9",
-        "@types/lodash-es": "^4.17.6",
-        "@types/uuid": "^9.0.0",
-        "core-js": "2.6.10",
         "json.date-extensions": "^1.2.2",
-        "rxjs": "^7.4.0",
         "tslib": "^2.0.0",
-        "uuid": "^9.0.0",
-        "zone.js": "~0.11.4"
+        "uuid": "^9.0.0"
       },
       "devDependencies": {
         "@angular-devkit/build-angular": "^15.2.8",
@@ -36,14 +22,18 @@
         "@angular-eslint/schematics": "^15.2.1",
         "@angular-eslint/template-parser": "15.2.1",
         "@angular/cli": "^15.2.8",
+        "@angular/common": "^15.2.0",
+        "@angular/compiler": "^15.2.0",
         "@angular/compiler-cli": "^15.2.9",
+        "@angular/core": "^15.2.0",
         "@angular/language-service": "^15.2.9",
         "@types/jasmine": "~3.6.0",
         "@types/jasminewd2": "~2.0.3",
+        "@types/lodash-es": "^4.17.6",
         "@types/node": "^12.11.1",
         "@typescript-eslint/eslint-plugin": "^5.46.1",
         "@typescript-eslint/parser": "^5.46.1",
-        "codelyzer": "^6.0.0",
+        "core-js": "2.6.10",
         "eslint": "^8.2.0",
         "jasmine-core": "^4.5.0",
         "jasmine-data-provider-ts": "^1.4.1",
@@ -60,12 +50,19 @@
       "engines": {
         "node": "^16.0.0",
         "npm": "^8.0.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "13 - 15",
+        "@angular/core": "13 - 15",
+        "@types/uuid": "^9.0.0",
+        "rxjs": "^7.4.0"
       }
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.0",
       "resolved": "https://npm.totvs.io/@ampproject%2fremapping/-/remapping-2.2.0.tgz",
       "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.1.0",
@@ -76,12 +73,12 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1502.8",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1502.8.tgz",
-      "integrity": "sha512-rTltw2ABHrcKc8EGimALvXmrDTP5hlNbEy6nYolJoXEI9EwHgriWrVLVPs3OEF+/ed47dbJi9EGOXUOgzgpB5A==",
+      "version": "0.1502.9",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1502.9.tgz",
+      "integrity": "sha512-CFn+LbtYeLG7WqO+BBSjogl764StHpwgfJnNAXQ/3UouUktZ92z4lxhUm0PwIPb5k0lILsf81ubcS1vzwoXEEg==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "15.2.8",
+        "@angular-devkit/core": "15.2.9",
         "rxjs": "6.6.7"
       },
       "engines": {
@@ -109,15 +106,15 @@
       "dev": true
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "15.2.8",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-15.2.8.tgz",
-      "integrity": "sha512-TGDnXhhOG6h6TOrWWzfnkha7wYBOXi7iJc1o1w1VKCayE3T6TZZdF847aK66vL9KG7AKYVdGhWEGw2WBHUBUpg==",
+      "version": "15.2.9",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-15.2.9.tgz",
+      "integrity": "sha512-djOo2Q22zLrxPccSbINz93hD+pES/nNPoze4Ys/0IdtMlLmxO/YGsA+FG5eNeNAf2jK/JRoNydaYOh7XpGoCzA==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "2.2.0",
-        "@angular-devkit/architect": "0.1502.8",
-        "@angular-devkit/build-webpack": "0.1502.8",
-        "@angular-devkit/core": "15.2.8",
+        "@angular-devkit/architect": "0.1502.9",
+        "@angular-devkit/build-webpack": "0.1502.9",
+        "@angular-devkit/core": "15.2.9",
         "@babel/core": "7.20.12",
         "@babel/generator": "7.20.14",
         "@babel/helper-annotate-as-pure": "7.18.6",
@@ -129,7 +126,7 @@
         "@babel/runtime": "7.20.13",
         "@babel/template": "7.20.7",
         "@discoveryjs/json-ext": "0.5.7",
-        "@ngtools/webpack": "15.2.8",
+        "@ngtools/webpack": "15.2.9",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.13",
         "babel-loader": "9.1.2",
@@ -162,7 +159,7 @@
         "rxjs": "6.6.7",
         "sass": "1.58.1",
         "sass-loader": "13.2.0",
-        "semver": "7.3.8",
+        "semver": "7.5.3",
         "source-map-loader": "4.0.1",
         "source-map-support": "0.5.21",
         "terser": "5.16.3",
@@ -249,24 +246,12 @@
       }
     },
     "node_modules/@angular-devkit/build-angular/node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@angular-devkit/build-angular/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@angular-devkit/build-angular/node_modules/rxjs": {
@@ -289,28 +274,13 @@
       "dev": true,
       "license": "0BSD"
     },
-    "node_modules/@angular-devkit/build-angular/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1502.8",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1502.8.tgz",
-      "integrity": "sha512-jWtNv+S03FFLDe/C8SPCcRvkz3bSb2R+919IT086Q9axIPQ1VowOEwzt2k3qXPSSrC7GSYuASM+X92dB47NTQQ==",
+      "version": "0.1502.9",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1502.9.tgz",
+      "integrity": "sha512-VzMXoZjrbL1XlcSegqpZCBDbVvKFGPs3cKp4bXDD5ht95jcCyJPk5FA/wrh0pGGwbOF8ae/XOWFcPRzctC35iA==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1502.8",
+        "@angular-devkit/architect": "0.1502.9",
         "rxjs": "6.6.7"
       },
       "engines": {
@@ -342,9 +312,9 @@
       "dev": true
     },
     "node_modules/@angular-devkit/core": {
-      "version": "15.2.8",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-15.2.8.tgz",
-      "integrity": "sha512-Lo4XrbDMtXarKnMrFgWLmQdSX+3QPNAg4otG8cmp/U4jJyjV4dAYKEAsb1sCNGUSM4h4v09EQU/5ugVjDU29lQ==",
+      "version": "15.2.9",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-15.2.9.tgz",
+      "integrity": "sha512-6u44YJ9tEG2hiWITL1rwA9yP6ot4a3cyN/UOMRkYSa/XO2Gz5/dM3U74E2kwg+P1NcxLXffBWl0rz8/Y/lSZyQ==",
       "dev": true,
       "dependencies": {
         "ajv": "8.12.0",
@@ -388,12 +358,12 @@
       "license": "0BSD"
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "15.2.8",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-15.2.8.tgz",
-      "integrity": "sha512-w6EUGC96kVsH9f8sEzajzbONMawezyVBiSo+JYp5r25rQArAz/a+KZntbuETWHQ0rQOEsKmUNKxwmr11BaptSQ==",
+      "version": "15.2.9",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-15.2.9.tgz",
+      "integrity": "sha512-o08nE8sTpfq/Fknrr1rzBsM8vY36BDox+8dOo9Zc/KqcVPwDy94YKRzHb+xxVaU9jy1VYeCjy63mkyELy7Z3zQ==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "15.2.8",
+        "@angular-devkit/core": "15.2.9",
         "jsonc-parser": "3.2.0",
         "magic-string": "0.29.0",
         "ora": "5.4.1",
@@ -515,30 +485,16 @@
         "typescript": "*"
       }
     },
-    "node_modules/@angular/animations": {
-      "version": "15.2.9",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-15.2.9.tgz",
-      "integrity": "sha512-GQujLhI0cQFcl4Q8y0oSYKSRnW23GIeSL+Arl4eFufziJ9hGAAQNuesaNs/7i+9UlTHDMkPH3kd5ScXuYYz6wg==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": "^14.20.0 || ^16.13.0 || >=18.10.0"
-      },
-      "peerDependencies": {
-        "@angular/core": "15.2.9"
-      }
-    },
     "node_modules/@angular/cli": {
-      "version": "15.2.8",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-15.2.8.tgz",
-      "integrity": "sha512-3VlTfm6DUZfFHBY43vQSAaqmFTxy3VtRd/iDBCHcEPhHwYLWBvNwReJuJfNja8O105QQ6DBiYVBExEBtPmjQ4w==",
+      "version": "15.2.9",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-15.2.9.tgz",
+      "integrity": "sha512-mI6hkGyIJDKd8MRiBl3p5chsUhgnluwmpsq3g1FFPw+wv+eXsPYgCiHqXS/OsK+shFxii9XMxoZQO28bJ4NAOQ==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1502.8",
-        "@angular-devkit/core": "15.2.8",
-        "@angular-devkit/schematics": "15.2.8",
-        "@schematics/angular": "15.2.8",
+        "@angular-devkit/architect": "0.1502.9",
+        "@angular-devkit/core": "15.2.9",
+        "@angular-devkit/schematics": "15.2.9",
+        "@schematics/angular": "15.2.9",
         "@yarnpkg/lockfile": "1.1.0",
         "ansi-colors": "4.1.3",
         "ini": "3.0.1",
@@ -550,7 +506,7 @@
         "ora": "5.4.1",
         "pacote": "15.1.0",
         "resolve": "1.22.1",
-        "semver": "7.3.8",
+        "semver": "7.5.3",
         "symbol-observable": "4.0.0",
         "yargs": "17.6.2"
       },
@@ -563,37 +519,11 @@
         "yarn": ">= 1.13.0"
       }
     },
-    "node_modules/@angular/cli/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@angular/cli/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@angular/common": {
       "version": "15.2.9",
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-15.2.9.tgz",
       "integrity": "sha512-LM9/UHG2dRrOzlu2KovrFwWIziFMjRxHzSP3Igw6Symw/wIl0kXGq8Fn6RpFP78zmLqnv+IQOoRiby9MCXsI4g==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -609,6 +539,7 @@
       "version": "15.2.9",
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-15.2.9.tgz",
       "integrity": "sha512-MoKugbjk+E0wRBj12uvIyDLELlVLonnqjA2+XiF+7FxALIeyds3/qQeEoMmYIqAbN3NnTT5pV92RxWwG4tHFwA==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -628,6 +559,7 @@
       "version": "15.2.9",
       "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-15.2.9.tgz",
       "integrity": "sha512-zsbI8G2xHOeYWI0hjFzrI//ZhZV9il/uQW5dAimfwJp06KZDeXZ3PdwY9JQslf6F+saLwOObxy6QMrIVvfjy9w==",
+      "dev": true,
       "dependencies": {
         "@babel/core": "7.19.3",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -657,6 +589,7 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
       "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.13"
       },
@@ -668,6 +601,7 @@
       "version": "15.2.9",
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-15.2.9.tgz",
       "integrity": "sha512-w46Z1yUXCQfKV7XfnamOoLA2VD0MVUUYVrUjO73mHSskDXSXxfZAEHO9kfUS71Cj35PvhP3mbkqWscpea2WeYg==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -677,23 +611,6 @@
       "peerDependencies": {
         "rxjs": "^6.5.3 || ^7.4.0",
         "zone.js": "~0.11.4 || ~0.12.0 || ~0.13.0"
-      }
-    },
-    "node_modules/@angular/forms": {
-      "version": "15.2.9",
-      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-15.2.9.tgz",
-      "integrity": "sha512-sk0pC2EFi2Ohg5J0q0NYptbT+2WOkoiERSMYA39ncDvlSZBWsNlxpkbGUSck7NIxjK2QfcVN1ldGbHlZTFvtqg==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": "^14.20.0 || ^16.13.0 || >=18.10.0"
-      },
-      "peerDependencies": {
-        "@angular/common": "15.2.9",
-        "@angular/core": "15.2.9",
-        "@angular/platform-browser": "15.2.9",
-        "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/language-service": {
@@ -709,6 +626,9 @@
       "version": "15.2.9",
       "resolved": "https://registry.npmjs.org/@angular/localize/-/localize-15.2.9.tgz",
       "integrity": "sha512-7ZGK3BWwIukSK5ORWjM3y/FYj7/ZJFl1RO1GCeL/tHD4nq0kd3q3pYvcpnoi9HGl+q8AkL24xdsfzgCFo8SB0g==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/core": "7.19.3",
         "glob": "8.1.0",
@@ -727,61 +647,6 @@
         "@angular/compiler-cli": "15.2.9"
       }
     },
-    "node_modules/@angular/platform-browser": {
-      "version": "15.2.9",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-15.2.9.tgz",
-      "integrity": "sha512-ufCHeSX+U6d43YOMkn3igwfqtlozoCXADcbyfUEG8m2y9XASobqmCKvdSk/zfl62oyiA8msntWBJVBE2l4xKXg==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": "^14.20.0 || ^16.13.0 || >=18.10.0"
-      },
-      "peerDependencies": {
-        "@angular/animations": "15.2.9",
-        "@angular/common": "15.2.9",
-        "@angular/core": "15.2.9"
-      },
-      "peerDependenciesMeta": {
-        "@angular/animations": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@angular/platform-browser-dynamic": {
-      "version": "15.2.9",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-15.2.9.tgz",
-      "integrity": "sha512-ZIYDM6MShblb8OyV1m4+18lJJ2LCeICmeg2uSbpFYptYBSOClrTiYOOFVDJvn7HLvNzljLs16XPrgyaYVqNpcw==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": "^14.20.0 || ^16.13.0 || >=18.10.0"
-      },
-      "peerDependencies": {
-        "@angular/common": "15.2.9",
-        "@angular/compiler": "15.2.9",
-        "@angular/core": "15.2.9",
-        "@angular/platform-browser": "15.2.9"
-      }
-    },
-    "node_modules/@angular/router": {
-      "version": "15.2.9",
-      "resolved": "https://registry.npmjs.org/@angular/router/-/router-15.2.9.tgz",
-      "integrity": "sha512-UCbh5DLSDhybv0xKYT7kGQMfOVdyhHIHOZz5EYVebbhste6S+W1LE57vTHq7QtxJsyKBa/WSkaUkCLXD6ntCAg==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": "^14.20.0 || ^16.13.0 || >=18.10.0"
-      },
-      "peerDependencies": {
-        "@angular/common": "15.2.9",
-        "@angular/core": "15.2.9",
-        "@angular/platform-browser": "15.2.9",
-        "rxjs": "^6.5.3 || ^7.4.0"
-      }
-    },
     "node_modules/@assemblyscript/loader": {
       "version": "0.10.1",
       "resolved": "https://npm.totvs.io/@assemblyscript%2floader/-/loader-0.10.1.tgz",
@@ -793,6 +658,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.5.tgz",
       "integrity": "sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==",
+      "dev": true,
       "dependencies": {
         "@babel/highlight": "^7.22.5"
       },
@@ -804,6 +670,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.5.tgz",
       "integrity": "sha512-4Jc/YuIaYqKnDDz892kPIledykKg12Aw1PYX5i/TY28anJtacvM1Rrr8wbieB9GfEJwlzqT0hUEao0CxEebiDA==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -812,6 +679,7 @@
       "version": "7.19.3",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.3.tgz",
       "integrity": "sha512-WneDJxdsjEvyKtXKsaBGbDeiyOjR5vYq4HcShxnIbG0qixpoHjI3MqeZM9NDvsojNCEBItQE4juOo/bU6e72gQ==",
+      "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
@@ -838,10 +706,10 @@
       }
     },
     "node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://npm.totvs.io/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "license": "ISC",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -850,6 +718,7 @@
       "version": "7.20.14",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.14.tgz",
       "integrity": "sha512-AEmuXHdcD3A52HHXxaTmYlb8q/xMEhoRP67B3T4Oq7lbmSoqroMZzjnGj3+i1io3pdnF8iBYVu4Ilj+c4hBxYg==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.20.7",
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -863,6 +732,7 @@
       "version": "0.3.2",
       "resolved": "https://npm.totvs.io/@jridgewell%2fgen-mapping/-/gen-mapping-0.3.2.tgz",
       "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/set-array": "^1.0.1",
@@ -901,6 +771,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.5.tgz",
       "integrity": "sha512-Ji+ywpHeuqxB8WDxraCiqR0xfhYjiDE/e6k7FuIaANnoOFxAHskHChz4vA1mJC9Lbm01s1PVAGhQY4FUKSkGZw==",
+      "dev": true,
       "dependencies": {
         "@babel/compat-data": "^7.22.5",
         "@babel/helper-validator-option": "^7.22.5",
@@ -916,10 +787,10 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://npm.totvs.io/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "license": "ISC",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -972,9 +843,9 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -1010,9 +881,9 @@
       }
     },
     "node_modules/@babel/helper-create-regexp-features-plugin/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -1036,9 +907,9 @@
       }
     },
     "node_modules/@babel/helper-define-polyfill-provider/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -1048,6 +919,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.5.tgz",
       "integrity": "sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1056,6 +928,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.22.5.tgz",
       "integrity": "sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==",
+      "dev": true,
       "dependencies": {
         "@babel/template": "^7.22.5",
         "@babel/types": "^7.22.5"
@@ -1068,6 +941,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.5.tgz",
       "integrity": "sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==",
+      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.22.5",
         "@babel/parser": "^7.22.5",
@@ -1081,6 +955,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
       "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.22.5"
       },
@@ -1104,6 +979,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.5.tgz",
       "integrity": "sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.22.5"
       },
@@ -1115,6 +991,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.22.5.tgz",
       "integrity": "sha512-+hGKDt/Ze8GFExiVHno/2dvG5IdstpzCq0y4Qc9OJ25D4q3pKfiIP/4Vp3/JvhDkLKsDK2api3q3fpIgiIF5bw==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.22.5",
         "@babel/helper-module-imports": "^7.22.5",
@@ -1133,6 +1010,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.5.tgz",
       "integrity": "sha512-thqK5QFghPKWLhAV321lxF95yCg2K3Ob5yw+M3VHWfdia0IkPXUtoLH8x/6Fh486QUvzhb8YOWHChTVen2/PoQ==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.22.5"
       },
@@ -1144,6 +1022,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.5.tgz",
       "integrity": "sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==",
+      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.22.5",
         "@babel/parser": "^7.22.5",
@@ -1239,6 +1118,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
       "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.22.5"
       },
@@ -1275,6 +1155,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
       "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1283,6 +1164,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
       "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1291,6 +1173,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.5.tgz",
       "integrity": "sha512-R3oB6xlIVKUnxNUxbmgq7pKjxpru24zlimpE8WK47fACIlM0II/Hm1RS8IaOI7NgCr6LNS+jl5l75m20npAziw==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1328,6 +1211,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.5.tgz",
       "integrity": "sha512-pSXRmfE1vzcUIDFQcSGA5Mr+GxBV9oiRKDuDxXvWQQBCh8HoIjs/2DlDB7H8smac1IVrB9/xdXj2N3Wol9Cr+Q==",
+      "dev": true,
       "dependencies": {
         "@babel/template": "^7.22.5",
         "@babel/traverse": "^7.22.5",
@@ -1341,6 +1225,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.5.tgz",
       "integrity": "sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==",
+      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.22.5",
         "@babel/parser": "^7.22.5",
@@ -1354,6 +1239,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.5.tgz",
       "integrity": "sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.22.5",
         "chalk": "^2.0.0",
@@ -1367,6 +1253,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.5.tgz",
       "integrity": "sha512-DFZMC9LJUG9PLOclRC32G63UXwzqS2koQC8dkx+PLdmt1xSePYpbT/NbsrJy8Q/muXz7o/h/d4A7Fuyixm559Q==",
+      "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -2323,9 +2210,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-runtime/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -2528,9 +2415,9 @@
       }
     },
     "node_modules/@babel/preset-env/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -2574,6 +2461,7 @@
       "version": "7.20.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
       "integrity": "sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==",
+      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
         "@babel/parser": "^7.20.7",
@@ -2587,6 +2475,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.5.tgz",
       "integrity": "sha512-7DuIjPgERaNo6r+PZwItpjCZEa5vyw4eJGufeLxrPdBXBoLcCJCIasvK6pK/9DVNrLZTLFhUGqaC6X/PA007TQ==",
+      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.22.5",
         "@babel/generator": "^7.22.5",
@@ -2607,6 +2496,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.5.tgz",
       "integrity": "sha512-+lcUbnTRhd0jOewtFSedLyiPsD5tswKkbgcezOqqWFUVNEwoUTlpPOBmvhG7OXWLR4jMdv0czPGH5XbflnD1EA==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.22.5",
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -2621,6 +2511,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.5.tgz",
       "integrity": "sha512-thqK5QFghPKWLhAV321lxF95yCg2K3Ob5yw+M3VHWfdia0IkPXUtoLH8x/6Fh486QUvzhb8YOWHChTVen2/PoQ==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.22.5"
       },
@@ -2632,6 +2523,7 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
       "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/set-array": "^1.0.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -2645,6 +2537,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.5.tgz",
       "integrity": "sha512-zo3MIHGOkPOfoRXitsgHLjEXmlDaD/5KU1Uzuc9GNiZPhSqVxVRtxuPaSBZDsYZ9qV88AjtMtWW7ww98loJ9KA==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.22.5",
         "@babel/helper-validator-identifier": "^7.22.5",
@@ -3334,6 +3227,7 @@
       "version": "0.1.1",
       "resolved": "https://npm.totvs.io/@jridgewell%2fgen-mapping/-/gen-mapping-0.1.1.tgz",
       "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/set-array": "^1.0.0",
@@ -3347,6 +3241,7 @@
       "version": "3.1.0",
       "resolved": "https://npm.totvs.io/@jridgewell%2fresolve-uri/-/resolve-uri-3.1.0.tgz",
       "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -3356,6 +3251,7 @@
       "version": "1.1.2",
       "resolved": "https://npm.totvs.io/@jridgewell%2fset-array/-/set-array-1.1.2.tgz",
       "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -3391,12 +3287,14 @@
       "version": "1.4.14",
       "resolved": "https://npm.totvs.io/@jridgewell%2fsourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.17",
       "resolved": "https://npm.totvs.io/@jridgewell%2ftrace-mapping/-/trace-mapping-0.3.17.tgz",
       "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "3.1.0",
@@ -3410,9 +3308,9 @@
       "dev": true
     },
     "node_modules/@ngtools/webpack": {
-      "version": "15.2.8",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-15.2.8.tgz",
-      "integrity": "sha512-BJexeT4FxMtToVBGa3wdl6rrkYXgilP0kkSH4Qzu4MPlLPbeBSr4XQalQriewlpC2uzG0r2SJfrAe2eDhtSykA==",
+      "version": "15.2.9",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-15.2.9.tgz",
+      "integrity": "sha512-nOXUGqKkAEMlCcrhkDwWDzcVdKNH7MNRUXfNzsFc9zdeR/5p3qt6SVMN7OOE3NREyI7P6nzARc3S+6QDBjf3Jg==",
       "dev": true,
       "engines": {
         "node": "^14.20.0 || ^16.13.0 || >=18.10.0",
@@ -3679,13 +3577,13 @@
       }
     },
     "node_modules/@schematics/angular": {
-      "version": "15.2.8",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-15.2.8.tgz",
-      "integrity": "sha512-F49IEzCFxQlpaMIgTO/wF1l/CLQKif7VaiDdyiTKOeT22IMmyd61FUmWDyZYfCBqMlvBmvDGx64HaHWes1HYCg==",
+      "version": "15.2.9",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-15.2.9.tgz",
+      "integrity": "sha512-0Lit6TLNUwcAYiEkXgZp3vY9xAO1cnZCBXuUcp+6v+Ddnrt2w/YOiGe74p21cYe0StkTpTljsqsKBTiX7TMjQg==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "15.2.8",
-        "@angular-devkit/schematics": "15.2.8",
+        "@angular-devkit/core": "15.2.9",
+        "@angular-devkit/schematics": "15.2.9",
         "jsonc-parser": "3.2.0"
       },
       "engines": {
@@ -3719,10 +3617,9 @@
     },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.0",
-      "resolved": "https://npm.totvs.io/@socket.io%2fcomponent-emitter/-/component-emitter-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
       "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
@@ -3810,17 +3707,15 @@
     },
     "node_modules/@types/cookie": {
       "version": "0.4.1",
-      "resolved": "https://npm.totvs.io/@types%2fcookie/-/cookie-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
       "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/@types/cors": {
       "version": "2.8.13",
-      "resolved": "https://npm.totvs.io/@types%2fcors/-/cors-2.8.13.tgz",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.13.tgz",
       "integrity": "sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -3866,9 +3761,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.17.35",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.35.tgz",
-      "integrity": "sha512-wALWQwrgiB2AWTT91CB62b6Yt0sNHpznUXeZEcnPU3DRdlDIz74x8Qg1UUYKSVFi+va5vKOLYRBI1bRKiLLKIg==",
+      "version": "4.17.36",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.36.tgz",
+      "integrity": "sha512-zbivROJ0ZqLAtMzgzIUC4oNqDG9iF0lSsAqpOD9kbs5xcIM3dTiyuHvBc7R8MtWBp3AAWGaovJa+wzWPjLYW7Q==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
@@ -3876,6 +3771,12 @@
         "@types/range-parser": "*",
         "@types/send": "*"
       }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-/K3ds8TRAfBvi5vfjuz8y6+GiAYBZ0x4tXv1Av6CWBWn0IlADc+ZX9pMq7oU0fNQPnBwIZl3rmeLp6SBApbxSQ==",
+      "dev": true
     },
     "node_modules/@types/http-proxy": {
       "version": "1.17.11",
@@ -3914,12 +3815,14 @@
       "version": "4.14.191",
       "resolved": "https://npm.totvs.io/@types%2flodash/-/lodash-4.14.191.tgz",
       "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/lodash-es": {
       "version": "4.17.6",
       "resolved": "https://npm.totvs.io/@types%2flodash-es/-/lodash-es-4.17.6.tgz",
       "integrity": "sha512-R+zTeVUKDdfoRxpAryaQNRKk3105Rrgx2CFRClIgRGaqDTdjsm8h6IYA8ir584W3ePzkZfst5xIgDwYrlh9HLg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/lodash": "*"
@@ -3995,11 +3898,12 @@
       }
     },
     "node_modules/@types/serve-static": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.1.tgz",
-      "integrity": "sha512-NUo5XNiAdULrJENtJXZZ3fHtfMolzZwczzBbnAeBbqBwG+LaG6YaJtuwzwGSQZ2wsCrxjEhNNjAkKigy3n8teQ==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.2.tgz",
+      "integrity": "sha512-J2LqtvFYCzaj8pVYKw8klQXrLLk7TBZmQ4ShlcdkELFKGwGMfevMLneMMRkMgZxotOD9wg497LpC7O8PcvAmfw==",
       "dev": true,
       "dependencies": {
+        "@types/http-errors": "*",
         "@types/mime": "*",
         "@types/node": "*"
       }
@@ -4017,7 +3921,8 @@
       "version": "9.0.0",
       "resolved": "https://npm.totvs.io/@types%2fuuid/-/uuid-9.0.0.tgz",
       "integrity": "sha512-kr90f+ERiQtKWMz5rP32ltJ/BtULDI5RVO0uavn1HQUOwjx0R1h0rnDYNL0CepF1zL5bSY6FISAfd9tOdDhU5Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/ws": {
       "version": "8.5.5",
@@ -4649,10 +4554,9 @@
     },
     "node_modules/accepts": {
       "version": "1.3.8",
-      "resolved": "https://npm.totvs.io/accepts/-/accepts-1.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
       "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "mime-types": "~2.1.34",
         "negotiator": "0.6.3"
@@ -4852,6 +4756,7 @@
       "version": "5.0.1",
       "resolved": "https://npm.totvs.io/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4861,6 +4766,7 @@
       "version": "3.2.1",
       "resolved": "https://npm.totvs.io/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^1.9.0"
@@ -4873,6 +4779,7 @@
       "version": "3.1.3",
       "resolved": "https://npm.totvs.io/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -4880,16 +4787,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/app-root-path": {
-      "version": "3.1.0",
-      "resolved": "https://npm.totvs.io/app-root-path/-/app-root-path-3.1.0.tgz",
-      "integrity": "sha512-biN3PwB2gUtjaYy/isrU3aNWI5w+fAfvHkSvCKeQGxhmYpwKFUxudR3Yya+KqVRHBmEDYh+/lTozYCFbmzX4nA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6.0.0"
       }
     },
     "node_modules/aproba": {
@@ -4963,13 +4860,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/ast-types-flow": {
-      "version": "0.0.7",
-      "resolved": "https://npm.totvs.io/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
-      "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/autoprefixer": {
       "version": "10.4.13",
@@ -5076,9 +4966,9 @@
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -5113,6 +5003,7 @@
       "version": "1.0.2",
       "resolved": "https://npm.totvs.io/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
@@ -5138,10 +5029,9 @@
     },
     "node_modules/base64id": {
       "version": "2.0.0",
-      "resolved": "https://npm.totvs.io/base64id/-/base64id-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
       "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^4.5.0 || >= 5.9"
       }
@@ -5166,6 +5056,7 @@
       "version": "2.2.0",
       "resolved": "https://npm.totvs.io/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5248,6 +5139,7 @@
       "version": "2.0.1",
       "resolved": "https://npm.totvs.io/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -5257,6 +5149,7 @@
       "version": "3.0.2",
       "resolved": "https://npm.totvs.io/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.0.1"
@@ -5269,6 +5162,7 @@
       "version": "4.21.5",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
       "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -5426,6 +5320,7 @@
       "version": "1.0.30001506",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001506.tgz",
       "integrity": "sha512-6XNEcpygZMCKaufIcgpQNZNf00GEqc7VQON+9Rd0K1bMYo8xhMZRAo5zpbnbMNizi4YNgIDAFrdykWsvY3H4Hw==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -5445,6 +5340,7 @@
       "version": "2.4.2",
       "resolved": "https://npm.totvs.io/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^3.2.1",
@@ -5466,6 +5362,7 @@
       "version": "3.5.3",
       "resolved": "https://npm.totvs.io/chokidar/-/chokidar-3.5.3.tgz",
       "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -5590,125 +5487,11 @@
         "node": ">=6"
       }
     },
-    "node_modules/codelyzer": {
-      "version": "6.0.2",
-      "resolved": "https://npm.totvs.io/codelyzer/-/codelyzer-6.0.2.tgz",
-      "integrity": "sha512-v3+E0Ucu2xWJMOJ2fA/q9pDT/hlxHftHGPUay1/1cTgyPV5JTHFdO9hqo837Sx2s9vKBMTt5gO+lhF95PO6J+g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@angular/compiler": "9.0.0",
-        "@angular/core": "9.0.0",
-        "app-root-path": "^3.0.0",
-        "aria-query": "^3.0.0",
-        "axobject-query": "2.0.2",
-        "css-selector-tokenizer": "^0.7.1",
-        "cssauron": "^1.4.0",
-        "damerau-levenshtein": "^1.0.4",
-        "rxjs": "^6.5.3",
-        "semver-dsl": "^1.0.1",
-        "source-map": "^0.5.7",
-        "sprintf-js": "^1.1.2",
-        "tslib": "^1.10.0",
-        "zone.js": "~0.10.3"
-      },
-      "peerDependencies": {
-        "@angular/compiler": ">=2.3.1 <13.0.0 || ^12.0.0-next || ^12.1.0-next || ^12.2.0-next",
-        "@angular/core": ">=2.3.1 <13.0.0 || ^12.0.0-next || ^12.1.0-next || ^12.2.0-next",
-        "tslint": "^5.0.0 || ^6.0.0"
-      }
-    },
-    "node_modules/codelyzer/node_modules/@angular/compiler": {
-      "version": "9.0.0",
-      "resolved": "https://npm.totvs.io/@angular%2fcompiler/-/compiler-9.0.0.tgz",
-      "integrity": "sha512-ctjwuntPfZZT2mNj2NDIVu51t9cvbhl/16epc5xEwyzyDt76pX9UgwvY+MbXrf/C/FWwdtmNtfP698BKI+9leQ==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "tslib": "^1.10.0"
-      }
-    },
-    "node_modules/codelyzer/node_modules/@angular/core": {
-      "version": "9.0.0",
-      "resolved": "https://npm.totvs.io/@angular%2fcore/-/core-9.0.0.tgz",
-      "integrity": "sha512-6Pxgsrf0qF9iFFqmIcWmjJGkkCaCm6V5QNnxMy2KloO3SDq6QuMVRbN9RtC8Urmo25LP+eZ6ZgYqFYpdD8Hd9w==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "rxjs": "^6.5.3",
-        "tslib": "^1.10.0",
-        "zone.js": "~0.10.2"
-      }
-    },
-    "node_modules/codelyzer/node_modules/aria-query": {
-      "version": "3.0.0",
-      "resolved": "https://npm.totvs.io/aria-query/-/aria-query-3.0.0.tgz",
-      "integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "ast-types-flow": "0.0.7",
-        "commander": "^2.11.0"
-      }
-    },
-    "node_modules/codelyzer/node_modules/axobject-query": {
-      "version": "2.0.2",
-      "resolved": "https://npm.totvs.io/axobject-query/-/axobject-query-2.0.2.tgz",
-      "integrity": "sha512-MCeek8ZH7hKyO1rWUbKNQBbl4l2eY0ntk7OGi+q0RlafrCnfPxC06WZA+uebCfmYp4mNU9jRBP1AhGyf8+W3ww==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "ast-types-flow": "0.0.7"
-      }
-    },
-    "node_modules/codelyzer/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://npm.totvs.io/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/codelyzer/node_modules/rxjs": {
-      "version": "6.6.7",
-      "resolved": "https://npm.totvs.io/rxjs/-/rxjs-6.6.7.tgz",
-      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^1.9.0"
-      },
-      "engines": {
-        "npm": ">=2.0.0"
-      }
-    },
-    "node_modules/codelyzer/node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://npm.totvs.io/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/codelyzer/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://npm.totvs.io/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true,
-      "license": "0BSD"
-    },
-    "node_modules/codelyzer/node_modules/zone.js": {
-      "version": "0.10.3",
-      "resolved": "https://npm.totvs.io/zone.js/-/zone.js-0.10.3.tgz",
-      "integrity": "sha512-LXVLVEq0NNOqK/fLJo3d0kfzd4sxwn2/h67/02pjCjfKDxgx1i9QqpvtHD8CrBnSSwMw5+dy11O7FRX5mkO7Cg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://npm.totvs.io/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
@@ -5718,6 +5501,7 @@
       "version": "1.1.3",
       "resolved": "https://npm.totvs.io/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/color-support": {
@@ -5891,14 +5675,14 @@
       "version": "1.9.0",
       "resolved": "https://npm.totvs.io/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "0.4.2",
-      "resolved": "https://npm.totvs.io/cookie/-/cookie-0.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
       "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -5996,6 +5780,7 @@
       "version": "2.6.10",
       "resolved": "https://npm.totvs.io/core-js/-/core-js-2.6.10.tgz",
       "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT"
     },
@@ -6020,10 +5805,9 @@
     },
     "node_modules/cors": {
       "version": "2.8.5",
-      "resolved": "https://npm.totvs.io/cors/-/cors-2.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
       "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "object-assign": "^4",
         "vary": "^1"
@@ -6197,17 +5981,6 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
-    "node_modules/css-selector-tokenizer": {
-      "version": "0.7.3",
-      "resolved": "https://npm.totvs.io/css-selector-tokenizer/-/css-selector-tokenizer-0.7.3.tgz",
-      "integrity": "sha512-jWQv3oCEL5kMErj4wRnK/OPoBi0D+P1FR2cDCKYPaMeD2eW3/mttav8HT4hT1CKopiJI/psEULjkClhvJo4Lvg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "fastparse": "^1.1.2"
-      }
-    },
     "node_modules/css-what": {
       "version": "6.1.0",
       "resolved": "https://npm.totvs.io/css-what/-/css-what-6.1.0.tgz",
@@ -6219,16 +5992,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/cssauron": {
-      "version": "1.4.0",
-      "resolved": "https://npm.totvs.io/cssauron/-/cssauron-1.4.0.tgz",
-      "integrity": "sha1-pmAt/34EqDBtwNuaVR6S6LVmKtg=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "through": "X.X.X"
       }
     },
     "node_modules/cssesc": {
@@ -6257,13 +6020,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/damerau-levenshtein": {
-      "version": "1.0.8",
-      "resolved": "https://npm.totvs.io/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
-      "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
     "node_modules/date-format": {
       "version": "4.0.14",
       "resolved": "https://npm.totvs.io/date-format/-/date-format-4.0.14.tgz",
@@ -6278,6 +6034,7 @@
       "version": "4.3.4",
       "resolved": "https://npm.totvs.io/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
@@ -6405,6 +6162,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.11.0.tgz",
       "integrity": "sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -6463,9 +6221,9 @@
       "dev": true
     },
     "node_modules/dns-packet": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.0.tgz",
-      "integrity": "sha512-rza3UH1LwdHh9qyPXp8lkwpjSNk/AMD3dPytUoRoqnypDUhY0xvbdmVhWOfxO68frEfV9BU8V12Ez7ZsHGZpCQ==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
+      "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
       "dev": true,
       "dependencies": {
         "@leichtgewicht/ip-codec": "^2.0.1"
@@ -6576,12 +6334,14 @@
       "version": "1.4.284",
       "resolved": "https://npm.totvs.io/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
       "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://npm.totvs.io/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/emojis-list": {
@@ -6628,11 +6388,10 @@
       }
     },
     "node_modules/engine.io": {
-      "version": "6.2.1",
-      "resolved": "https://npm.totvs.io/engine.io/-/engine.io-6.2.1.tgz",
-      "integrity": "sha512-ECceEFcAaNRybd3lsGQKas3ZlMVjN3cyWwMP25D2i0zWfyiytVbTpRPa34qrr+FHddtpBVOmq4H/DCv1O0lZRA==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.2.tgz",
+      "integrity": "sha512-IXsMcGpw/xRfjra46sVZVHiSWo/nJ/3g1337q9KNXtS6YRzbW5yIzTCb9DjhrBe7r3GZQR0I4+nq+4ODk5g/cA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/cookie": "^0.4.1",
         "@types/cors": "^2.8.12",
@@ -6642,19 +6401,18 @@
         "cookie": "~0.4.1",
         "cors": "~2.8.5",
         "debug": "~4.3.1",
-        "engine.io-parser": "~5.0.3",
-        "ws": "~8.2.3"
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.11.0"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=10.2.0"
       }
     },
     "node_modules/engine.io-parser": {
-      "version": "5.0.4",
-      "resolved": "https://npm.totvs.io/engine.io-parser/-/engine.io-parser-5.0.4.tgz",
-      "integrity": "sha512-+nVFp+5z1E3HcToEnO7ZIj3g+3k9389DvWtvJZz0T6/eOCPIyyxehFcedoYrZQrp0LgQbD9pPXhpMBKMd5QURg==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.1.tgz",
+      "integrity": "sha512-9JktcM3u18nU9N2Lz3bWeBgxVgOKpw7yhRaoxQA3FUDZzzw+9WlA6p4G4u0RixNkg14fH7EfEc/RhpurtiROTQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -6808,6 +6566,7 @@
       "version": "3.1.1",
       "resolved": "https://npm.totvs.io/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6824,6 +6583,7 @@
       "version": "1.0.5",
       "resolved": "https://npm.totvs.io/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
@@ -7521,13 +7281,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fastparse": {
-      "version": "1.1.2",
-      "resolved": "https://npm.totvs.io/fastparse/-/fastparse-1.1.2.tgz",
-      "integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/fastq": {
       "version": "1.14.0",
       "resolved": "https://npm.totvs.io/fastq/-/fastq-1.14.0.tgz",
@@ -7583,6 +7336,7 @@
       "version": "7.0.1",
       "resolved": "https://npm.totvs.io/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -7813,12 +7567,14 @@
       "version": "1.0.0",
       "resolved": "https://npm.totvs.io/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://npm.totvs.io/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -7869,6 +7625,7 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://npm.totvs.io/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -7878,6 +7635,7 @@
       "version": "2.0.5",
       "resolved": "https://npm.totvs.io/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -7924,6 +7682,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
       "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -7942,6 +7701,7 @@
       "version": "5.1.2",
       "resolved": "https://npm.totvs.io/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -7961,6 +7721,7 @@
       "version": "11.12.0",
       "resolved": "https://npm.totvs.io/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -8047,6 +7808,7 @@
       "version": "3.0.0",
       "resolved": "https://npm.totvs.io/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -8189,9 +7951,9 @@
       }
     },
     "node_modules/html-entities": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.6.tgz",
-      "integrity": "sha512-9o0+dcpIw2/HxkNuYKxSJUF/MMRZQECK4GnF+oQOmJ83yCVHTWgCH5aOXxK5bozNRmM8wtgryjHD3uloPBDEGw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.4.0.tgz",
+      "integrity": "sha512-igBTJcNNNhvZFRtm8uA6xMY6xYleeDwn3PeBCkDz7tHttv4F2hsDI2aPgNERWzvRcNYHNT3ymRaQzllmXj4YsQ==",
       "dev": true,
       "funding": [
         {
@@ -8492,6 +8254,7 @@
       "version": "1.0.6",
       "resolved": "https://npm.totvs.io/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -8502,6 +8265,7 @@
       "version": "2.0.4",
       "resolved": "https://npm.totvs.io/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -8680,6 +8444,7 @@
       "version": "2.1.0",
       "resolved": "https://npm.totvs.io/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -8781,6 +8546,7 @@
       "version": "2.1.1",
       "resolved": "https://npm.totvs.io/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8790,6 +8556,7 @@
       "version": "3.0.0",
       "resolved": "https://npm.totvs.io/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8799,6 +8566,7 @@
       "version": "4.0.3",
       "resolved": "https://npm.totvs.io/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -8843,6 +8611,7 @@
       "version": "7.0.0",
       "resolved": "https://npm.totvs.io/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -9110,11 +8879,10 @@
       }
     },
     "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://npm.totvs.io/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -9283,7 +9051,8 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "node_modules/js-yaml": {
       "version": "3.14.1",
@@ -9303,6 +9072,7 @@
       "version": "2.5.2",
       "resolved": "https://npm.totvs.io/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -9342,6 +9112,7 @@
       "version": "2.2.2",
       "resolved": "https://npm.totvs.io/json5/-/json5-2.2.2.tgz",
       "integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -9697,9 +9468,9 @@
       }
     },
     "node_modules/less/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
       "optional": true,
       "bin": {
@@ -9921,6 +9692,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
       }
@@ -9928,7 +9700,8 @@
     "node_modules/lru-cache/node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true
     },
     "node_modules/magic-string": {
       "version": "0.29.0",
@@ -9959,11 +9732,10 @@
       }
     },
     "node_modules/make-dir/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://npm.totvs.io/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -10162,6 +9934,7 @@
       "version": "5.1.0",
       "resolved": "https://npm.totvs.io/minimatch/-/minimatch-5.1.0.tgz",
       "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -10374,6 +10147,7 @@
       "version": "2.1.2",
       "resolved": "https://npm.totvs.io/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/multicast-dns": {
@@ -10656,6 +10430,7 @@
       "version": "2.0.8",
       "resolved": "https://npm.totvs.io/node-releases/-/node-releases-2.0.8.tgz",
       "integrity": "sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/nopt": {
@@ -10692,6 +10467,7 @@
       "version": "3.0.0",
       "resolved": "https://npm.totvs.io/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10850,10 +10626,9 @@
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
-      "resolved": "https://npm.totvs.io/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10946,6 +10721,7 @@
       "version": "1.4.0",
       "resolved": "https://npm.totvs.io/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -11459,12 +11235,14 @@
       "version": "1.0.0",
       "resolved": "https://npm.totvs.io/picocolors/-/picocolors-1.0.0.tgz",
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://npm.totvs.io/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -11976,6 +11754,7 @@
       "version": "3.6.0",
       "resolved": "https://npm.totvs.io/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -11987,7 +11766,8 @@
     "node_modules/reflect-metadata": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
-      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==",
+      "dev": true
     },
     "node_modules/regenerate": {
       "version": "1.4.2",
@@ -12102,6 +11882,7 @@
       "version": "2.1.1",
       "resolved": "https://npm.totvs.io/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -12483,9 +12264,10 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
-      "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -12496,30 +12278,11 @@
         "node": ">=10"
       }
     },
-    "node_modules/semver-dsl": {
-      "version": "1.0.1",
-      "resolved": "https://npm.totvs.io/semver-dsl/-/semver-dsl-1.0.1.tgz",
-      "integrity": "sha1-02eN5VVeimH2Ke7QJTZq5fJzQKA=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^5.3.0"
-      }
-    },
-    "node_modules/semver-dsl/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://npm.totvs.io/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/semver/node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://npm.totvs.io/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -12799,36 +12562,37 @@
       }
     },
     "node_modules/socket.io": {
-      "version": "4.5.4",
-      "resolved": "https://npm.totvs.io/socket.io/-/socket.io-4.5.4.tgz",
-      "integrity": "sha512-m3GC94iK9MfIEeIBfbhJs5BqFibMtkRk8ZpKwG2QwxV0m/eEhPIV4ara6XCF1LWNAus7z58RodiZlAH71U3EhQ==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.2.tgz",
+      "integrity": "sha512-bvKVS29/I5fl2FGLNHuXlQaUH/BlzX1IN6S+NKLNZpBsPZIDH+90eQmCs2Railn4YUiww4SzUedJ6+uzwFnKLw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.4",
         "base64id": "~2.0.0",
+        "cors": "~2.8.5",
         "debug": "~4.3.2",
-        "engine.io": "~6.2.1",
-        "socket.io-adapter": "~2.4.0",
-        "socket.io-parser": "~4.2.1"
+        "engine.io": "~6.5.2",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=10.2.0"
       }
     },
     "node_modules/socket.io-adapter": {
-      "version": "2.4.0",
-      "resolved": "https://npm.totvs.io/socket.io-adapter/-/socket.io-adapter-2.4.0.tgz",
-      "integrity": "sha512-W4N+o69rkMEGVuk2D/cvca3uYsvGlMwsySWV447y99gUPghxq42BxqLNMndb+a1mm/5/7NeXVQS7RLa2XyXvYg==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.2.tgz",
+      "integrity": "sha512-87C3LO/NOMc+eMcpcxUBebGjkpMDkNBS9tf7KJqcDsmL936EChtVva71Dw2q4tQcuVC+hAUy4an2NO/sYXmwRA==",
       "dev": true,
-      "license": "MIT"
+      "dependencies": {
+        "ws": "~8.11.0"
+      }
     },
     "node_modules/socket.io-parser": {
-      "version": "4.2.1",
-      "resolved": "https://npm.totvs.io/socket.io-parser/-/socket.io-parser-4.2.1.tgz",
-      "integrity": "sha512-V4GrkLy+HeF1F/en3SpUaM+7XxYXpuMUWLGde1kSSh5nQMN4hLrbPIkD+otwh6q9R6NOQBN4AMaOZ2zVjui82g==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1"
@@ -13021,13 +12785,6 @@
         "wbuf": "^1.7.3"
       }
     },
-    "node_modules/sprintf-js": {
-      "version": "1.1.2",
-      "resolved": "https://npm.totvs.io/sprintf-js/-/sprintf-js-1.1.2.tgz",
-      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/ssri": {
       "version": "10.0.4",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.4.tgz",
@@ -13123,6 +12880,7 @@
       "version": "4.2.3",
       "resolved": "https://npm.totvs.io/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -13152,6 +12910,7 @@
       "version": "6.0.1",
       "resolved": "https://npm.totvs.io/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -13199,6 +12958,7 @@
       "version": "5.5.0",
       "resolved": "https://npm.totvs.io/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^3.0.0"
@@ -13500,6 +13260,7 @@
       "version": "2.0.0",
       "resolved": "https://npm.totvs.io/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -13509,6 +13270,7 @@
       "version": "5.0.1",
       "resolved": "https://npm.totvs.io/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -13577,163 +13339,6 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-    },
-    "node_modules/tslint": {
-      "version": "6.1.3",
-      "resolved": "https://npm.totvs.io/tslint/-/tslint-6.1.3.tgz",
-      "integrity": "sha512-IbR4nkT96EQOvKE2PW/djGz8iGNeJ4rF2mBfiYaR/nvUWYKJhLwimoJKgjIFEIDibBtOevj7BqCRL4oHeWWUCg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "builtin-modules": "^1.1.1",
-        "chalk": "^2.3.0",
-        "commander": "^2.12.1",
-        "diff": "^4.0.1",
-        "glob": "^7.1.1",
-        "js-yaml": "^3.13.1",
-        "minimatch": "^3.0.4",
-        "mkdirp": "^0.5.3",
-        "resolve": "^1.3.2",
-        "semver": "^5.3.0",
-        "tslib": "^1.13.0",
-        "tsutils": "^2.29.0"
-      },
-      "bin": {
-        "tslint": "bin/tslint"
-      },
-      "engines": {
-        "node": ">=4.8.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev || >= 4.0.0-dev"
-      }
-    },
-    "node_modules/tslint/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://npm.totvs.io/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/tslint/node_modules/builtin-modules": {
-      "version": "1.1.1",
-      "resolved": "https://npm.totvs.io/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/tslint/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://npm.totvs.io/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/tslint/node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://npm.totvs.io/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "node_modules/tslint/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://npm.totvs.io/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/tslint/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://npm.totvs.io/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/tslint/node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://npm.totvs.io/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/tslint/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://npm.totvs.io/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/tslint/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://npm.totvs.io/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true,
-      "license": "0BSD",
-      "peer": true
-    },
-    "node_modules/tslint/node_modules/tsutils": {
-      "version": "2.29.0",
-      "resolved": "https://npm.totvs.io/tsutils/-/tsutils-2.29.0.tgz",
-      "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^1.8.1"
-      },
-      "peerDependencies": {
-        "typescript": ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev"
-      }
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -13823,6 +13428,7 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13832,9 +13438,9 @@
       }
     },
     "node_modules/ua-parser-js": {
-      "version": "0.7.32",
-      "resolved": "https://npm.totvs.io/ua-parser-js/-/ua-parser-js-0.7.32.tgz",
-      "integrity": "sha512-f9BESNVhzlhEFf2CHMSj40NWOjYPl1YKYbrvIr/hFTDEmLq7SRbWvm7FcdcpCYT95zrOhC7gZSxjdnnTpBcwVw==",
+      "version": "0.7.35",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.35.tgz",
+      "integrity": "sha512-veRf7dawaj9xaWEu9HoTVn5Pggtc/qj+kqTOFvNiN1l0YdxwC1kvel57UCjThjGa3BHBihE8/UJAHI+uQHmd/g==",
       "dev": true,
       "funding": [
         {
@@ -13846,7 +13452,6 @@
           "url": "https://paypal.me/faisalman"
         }
       ],
-      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -13929,6 +13534,7 @@
       "version": "1.0.10",
       "resolved": "https://npm.totvs.io/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
       "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -14011,10 +13617,9 @@
     },
     "node_modules/vary": {
       "version": "1.1.2",
-      "resolved": "https://npm.totvs.io/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -14208,27 +13813,6 @@
       },
       "peerDependencies": {
         "webpack": "^4.0.0 || ^5.0.0"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/ws": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/webpack-merge": {
@@ -14471,11 +14055,10 @@
       "license": "MIT"
     },
     "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://npm.totvs.io/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14484,6 +14067,7 @@
       "version": "7.0.0",
       "resolved": "https://npm.totvs.io/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -14552,6 +14136,7 @@
       "version": "4.3.0",
       "resolved": "https://npm.totvs.io/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -14567,6 +14152,7 @@
       "version": "2.0.1",
       "resolved": "https://npm.totvs.io/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -14579,20 +14165,21 @@
       "version": "1.1.4",
       "resolved": "https://npm.totvs.io/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://npm.totvs.io/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.2.3",
-      "resolved": "https://npm.totvs.io/ws/-/ws-8.2.3.tgz",
-      "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -14622,6 +14209,7 @@
       "version": "5.0.8",
       "resolved": "https://npm.totvs.io/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -14631,6 +14219,7 @@
       "version": "4.0.0",
       "resolved": "https://npm.totvs.io/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/yaml": {
@@ -14646,6 +14235,7 @@
       "version": "17.6.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
       "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+      "dev": true,
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -14663,6 +14253,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -14676,6 +14267,7 @@
       "version": "21.1.1",
       "resolved": "https://npm.totvs.io/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -14708,7 +14300,9 @@
       "version": "0.11.8",
       "resolved": "https://npm.totvs.io/zone.js/-/zone.js-0.11.8.tgz",
       "integrity": "sha512-82bctBg2hKcEJ21humWIkXRlLBBmrc3nN7DFh5LGGhcyycO2S7FN8NmdvlcKaGFDNVL4/9kFLmwmInTavdJERA==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       }
@@ -14719,18 +14313,19 @@
       "version": "2.2.0",
       "resolved": "https://npm.totvs.io/@ampproject%2fremapping/-/remapping-2.2.0.tgz",
       "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
+      "dev": true,
       "requires": {
         "@jridgewell/gen-mapping": "^0.1.0",
         "@jridgewell/trace-mapping": "^0.3.9"
       }
     },
     "@angular-devkit/architect": {
-      "version": "0.1502.8",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1502.8.tgz",
-      "integrity": "sha512-rTltw2ABHrcKc8EGimALvXmrDTP5hlNbEy6nYolJoXEI9EwHgriWrVLVPs3OEF+/ed47dbJi9EGOXUOgzgpB5A==",
+      "version": "0.1502.9",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1502.9.tgz",
+      "integrity": "sha512-CFn+LbtYeLG7WqO+BBSjogl764StHpwgfJnNAXQ/3UouUktZ92z4lxhUm0PwIPb5k0lILsf81ubcS1vzwoXEEg==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "15.2.8",
+        "@angular-devkit/core": "15.2.9",
         "rxjs": "6.6.7"
       },
       "dependencies": {
@@ -14752,15 +14347,15 @@
       }
     },
     "@angular-devkit/build-angular": {
-      "version": "15.2.8",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-15.2.8.tgz",
-      "integrity": "sha512-TGDnXhhOG6h6TOrWWzfnkha7wYBOXi7iJc1o1w1VKCayE3T6TZZdF847aK66vL9KG7AKYVdGhWEGw2WBHUBUpg==",
+      "version": "15.2.9",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-15.2.9.tgz",
+      "integrity": "sha512-djOo2Q22zLrxPccSbINz93hD+pES/nNPoze4Ys/0IdtMlLmxO/YGsA+FG5eNeNAf2jK/JRoNydaYOh7XpGoCzA==",
       "dev": true,
       "requires": {
         "@ampproject/remapping": "2.2.0",
-        "@angular-devkit/architect": "0.1502.8",
-        "@angular-devkit/build-webpack": "0.1502.8",
-        "@angular-devkit/core": "15.2.8",
+        "@angular-devkit/architect": "0.1502.9",
+        "@angular-devkit/build-webpack": "0.1502.9",
+        "@angular-devkit/core": "15.2.9",
         "@babel/core": "7.20.12",
         "@babel/generator": "7.20.14",
         "@babel/helper-annotate-as-pure": "7.18.6",
@@ -14772,7 +14367,7 @@
         "@babel/runtime": "7.20.13",
         "@babel/template": "7.20.7",
         "@discoveryjs/json-ext": "0.5.7",
-        "@ngtools/webpack": "15.2.8",
+        "@ngtools/webpack": "15.2.9",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.13",
         "babel-loader": "9.1.2",
@@ -14806,7 +14401,7 @@
         "rxjs": "6.6.7",
         "sass": "1.58.1",
         "sass-loader": "13.2.0",
-        "semver": "7.3.8",
+        "semver": "7.5.3",
         "source-map-loader": "4.0.1",
         "source-map-support": "0.5.21",
         "terser": "5.16.3",
@@ -14844,20 +14439,11 @@
           },
           "dependencies": {
             "semver": {
-              "version": "6.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+              "version": "6.3.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+              "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
               "dev": true
             }
-          }
-        },
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
           }
         },
         "rxjs": {
@@ -14876,25 +14462,16 @@
               "dev": true
             }
           }
-        },
-        "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
         }
       }
     },
     "@angular-devkit/build-webpack": {
-      "version": "0.1502.8",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1502.8.tgz",
-      "integrity": "sha512-jWtNv+S03FFLDe/C8SPCcRvkz3bSb2R+919IT086Q9axIPQ1VowOEwzt2k3qXPSSrC7GSYuASM+X92dB47NTQQ==",
+      "version": "0.1502.9",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1502.9.tgz",
+      "integrity": "sha512-VzMXoZjrbL1XlcSegqpZCBDbVvKFGPs3cKp4bXDD5ht95jcCyJPk5FA/wrh0pGGwbOF8ae/XOWFcPRzctC35iA==",
       "dev": true,
       "requires": {
-        "@angular-devkit/architect": "0.1502.8",
+        "@angular-devkit/architect": "0.1502.9",
         "rxjs": "6.6.7"
       },
       "dependencies": {
@@ -14916,9 +14493,9 @@
       }
     },
     "@angular-devkit/core": {
-      "version": "15.2.8",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-15.2.8.tgz",
-      "integrity": "sha512-Lo4XrbDMtXarKnMrFgWLmQdSX+3QPNAg4otG8cmp/U4jJyjV4dAYKEAsb1sCNGUSM4h4v09EQU/5ugVjDU29lQ==",
+      "version": "15.2.9",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-15.2.9.tgz",
+      "integrity": "sha512-6u44YJ9tEG2hiWITL1rwA9yP6ot4a3cyN/UOMRkYSa/XO2Gz5/dM3U74E2kwg+P1NcxLXffBWl0rz8/Y/lSZyQ==",
       "dev": true,
       "requires": {
         "ajv": "8.12.0",
@@ -14946,12 +14523,12 @@
       }
     },
     "@angular-devkit/schematics": {
-      "version": "15.2.8",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-15.2.8.tgz",
-      "integrity": "sha512-w6EUGC96kVsH9f8sEzajzbONMawezyVBiSo+JYp5r25rQArAz/a+KZntbuETWHQ0rQOEsKmUNKxwmr11BaptSQ==",
+      "version": "15.2.9",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-15.2.9.tgz",
+      "integrity": "sha512-o08nE8sTpfq/Fknrr1rzBsM8vY36BDox+8dOo9Zc/KqcVPwDy94YKRzHb+xxVaU9jy1VYeCjy63mkyELy7Z3zQ==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "15.2.8",
+        "@angular-devkit/core": "15.2.9",
         "jsonc-parser": "3.2.0",
         "magic-string": "0.29.0",
         "ora": "5.4.1",
@@ -15045,24 +14622,16 @@
         "@typescript-eslint/utils": "5.48.2"
       }
     },
-    "@angular/animations": {
-      "version": "15.2.9",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-15.2.9.tgz",
-      "integrity": "sha512-GQujLhI0cQFcl4Q8y0oSYKSRnW23GIeSL+Arl4eFufziJ9hGAAQNuesaNs/7i+9UlTHDMkPH3kd5ScXuYYz6wg==",
-      "requires": {
-        "tslib": "^2.3.0"
-      }
-    },
     "@angular/cli": {
-      "version": "15.2.8",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-15.2.8.tgz",
-      "integrity": "sha512-3VlTfm6DUZfFHBY43vQSAaqmFTxy3VtRd/iDBCHcEPhHwYLWBvNwReJuJfNja8O105QQ6DBiYVBExEBtPmjQ4w==",
+      "version": "15.2.9",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-15.2.9.tgz",
+      "integrity": "sha512-mI6hkGyIJDKd8MRiBl3p5chsUhgnluwmpsq3g1FFPw+wv+eXsPYgCiHqXS/OsK+shFxii9XMxoZQO28bJ4NAOQ==",
       "dev": true,
       "requires": {
-        "@angular-devkit/architect": "0.1502.8",
-        "@angular-devkit/core": "15.2.8",
-        "@angular-devkit/schematics": "15.2.8",
-        "@schematics/angular": "15.2.8",
+        "@angular-devkit/architect": "0.1502.9",
+        "@angular-devkit/core": "15.2.9",
+        "@angular-devkit/schematics": "15.2.9",
+        "@schematics/angular": "15.2.9",
         "@yarnpkg/lockfile": "1.1.0",
         "ansi-colors": "4.1.3",
         "ini": "3.0.1",
@@ -15074,35 +14643,16 @@
         "ora": "5.4.1",
         "pacote": "15.1.0",
         "resolve": "1.22.1",
-        "semver": "7.3.8",
+        "semver": "7.5.3",
         "symbol-observable": "4.0.0",
         "yargs": "17.6.2"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
       }
     },
     "@angular/common": {
       "version": "15.2.9",
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-15.2.9.tgz",
       "integrity": "sha512-LM9/UHG2dRrOzlu2KovrFwWIziFMjRxHzSP3Igw6Symw/wIl0kXGq8Fn6RpFP78zmLqnv+IQOoRiby9MCXsI4g==",
+      "dev": true,
       "requires": {
         "tslib": "^2.3.0"
       }
@@ -15111,6 +14661,7 @@
       "version": "15.2.9",
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-15.2.9.tgz",
       "integrity": "sha512-MoKugbjk+E0wRBj12uvIyDLELlVLonnqjA2+XiF+7FxALIeyds3/qQeEoMmYIqAbN3NnTT5pV92RxWwG4tHFwA==",
+      "dev": true,
       "requires": {
         "tslib": "^2.3.0"
       }
@@ -15119,6 +14670,7 @@
       "version": "15.2.9",
       "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-15.2.9.tgz",
       "integrity": "sha512-zsbI8G2xHOeYWI0hjFzrI//ZhZV9il/uQW5dAimfwJp06KZDeXZ3PdwY9JQslf6F+saLwOObxy6QMrIVvfjy9w==",
+      "dev": true,
       "requires": {
         "@babel/core": "7.19.3",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -15136,6 +14688,7 @@
           "version": "0.27.0",
           "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
           "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+          "dev": true,
           "requires": {
             "@jridgewell/sourcemap-codec": "^1.4.13"
           }
@@ -15146,14 +14699,7 @@
       "version": "15.2.9",
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-15.2.9.tgz",
       "integrity": "sha512-w46Z1yUXCQfKV7XfnamOoLA2VD0MVUUYVrUjO73mHSskDXSXxfZAEHO9kfUS71Cj35PvhP3mbkqWscpea2WeYg==",
-      "requires": {
-        "tslib": "^2.3.0"
-      }
-    },
-    "@angular/forms": {
-      "version": "15.2.9",
-      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-15.2.9.tgz",
-      "integrity": "sha512-sk0pC2EFi2Ohg5J0q0NYptbT+2WOkoiERSMYA39ncDvlSZBWsNlxpkbGUSck7NIxjK2QfcVN1ldGbHlZTFvtqg==",
+      "dev": true,
       "requires": {
         "tslib": "^2.3.0"
       }
@@ -15168,34 +14714,13 @@
       "version": "15.2.9",
       "resolved": "https://registry.npmjs.org/@angular/localize/-/localize-15.2.9.tgz",
       "integrity": "sha512-7ZGK3BWwIukSK5ORWjM3y/FYj7/ZJFl1RO1GCeL/tHD4nq0kd3q3pYvcpnoi9HGl+q8AkL24xdsfzgCFo8SB0g==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "@babel/core": "7.19.3",
         "glob": "8.1.0",
         "yargs": "^17.2.1"
-      }
-    },
-    "@angular/platform-browser": {
-      "version": "15.2.9",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-15.2.9.tgz",
-      "integrity": "sha512-ufCHeSX+U6d43YOMkn3igwfqtlozoCXADcbyfUEG8m2y9XASobqmCKvdSk/zfl62oyiA8msntWBJVBE2l4xKXg==",
-      "requires": {
-        "tslib": "^2.3.0"
-      }
-    },
-    "@angular/platform-browser-dynamic": {
-      "version": "15.2.9",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-15.2.9.tgz",
-      "integrity": "sha512-ZIYDM6MShblb8OyV1m4+18lJJ2LCeICmeg2uSbpFYptYBSOClrTiYOOFVDJvn7HLvNzljLs16XPrgyaYVqNpcw==",
-      "requires": {
-        "tslib": "^2.3.0"
-      }
-    },
-    "@angular/router": {
-      "version": "15.2.9",
-      "resolved": "https://registry.npmjs.org/@angular/router/-/router-15.2.9.tgz",
-      "integrity": "sha512-UCbh5DLSDhybv0xKYT7kGQMfOVdyhHIHOZz5EYVebbhste6S+W1LE57vTHq7QtxJsyKBa/WSkaUkCLXD6ntCAg==",
-      "requires": {
-        "tslib": "^2.3.0"
       }
     },
     "@assemblyscript/loader": {
@@ -15208,6 +14733,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.5.tgz",
       "integrity": "sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==",
+      "dev": true,
       "requires": {
         "@babel/highlight": "^7.22.5"
       }
@@ -15215,12 +14741,14 @@
     "@babel/compat-data": {
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.5.tgz",
-      "integrity": "sha512-4Jc/YuIaYqKnDDz892kPIledykKg12Aw1PYX5i/TY28anJtacvM1Rrr8wbieB9GfEJwlzqT0hUEao0CxEebiDA=="
+      "integrity": "sha512-4Jc/YuIaYqKnDDz892kPIledykKg12Aw1PYX5i/TY28anJtacvM1Rrr8wbieB9GfEJwlzqT0hUEao0CxEebiDA==",
+      "dev": true
     },
     "@babel/core": {
       "version": "7.19.3",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.3.tgz",
       "integrity": "sha512-WneDJxdsjEvyKtXKsaBGbDeiyOjR5vYq4HcShxnIbG0qixpoHjI3MqeZM9NDvsojNCEBItQE4juOo/bU6e72gQ==",
+      "dev": true,
       "requires": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
@@ -15240,9 +14768,10 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://npm.totvs.io/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+          "dev": true
         }
       }
     },
@@ -15250,6 +14779,7 @@
       "version": "7.20.14",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.14.tgz",
       "integrity": "sha512-AEmuXHdcD3A52HHXxaTmYlb8q/xMEhoRP67B3T4Oq7lbmSoqroMZzjnGj3+i1io3pdnF8iBYVu4Ilj+c4hBxYg==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.20.7",
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -15260,6 +14790,7 @@
           "version": "0.3.2",
           "resolved": "https://npm.totvs.io/@jridgewell%2fgen-mapping/-/gen-mapping-0.3.2.tgz",
           "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+          "dev": true,
           "requires": {
             "@jridgewell/set-array": "^1.0.1",
             "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -15290,6 +14821,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.5.tgz",
       "integrity": "sha512-Ji+ywpHeuqxB8WDxraCiqR0xfhYjiDE/e6k7FuIaANnoOFxAHskHChz4vA1mJC9Lbm01s1PVAGhQY4FUKSkGZw==",
+      "dev": true,
       "requires": {
         "@babel/compat-data": "^7.22.5",
         "@babel/helper-validator-option": "^7.22.5",
@@ -15299,9 +14831,10 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://npm.totvs.io/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+          "dev": true
         }
       }
     },
@@ -15341,9 +14874,9 @@
           }
         },
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -15369,9 +14902,9 @@
           }
         },
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -15391,9 +14924,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -15401,12 +14934,14 @@
     "@babel/helper-environment-visitor": {
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.5.tgz",
-      "integrity": "sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q=="
+      "integrity": "sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==",
+      "dev": true
     },
     "@babel/helper-function-name": {
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.22.5.tgz",
       "integrity": "sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==",
+      "dev": true,
       "requires": {
         "@babel/template": "^7.22.5",
         "@babel/types": "^7.22.5"
@@ -15416,6 +14951,7 @@
           "version": "7.22.5",
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.5.tgz",
           "integrity": "sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==",
+          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.22.5",
             "@babel/parser": "^7.22.5",
@@ -15428,6 +14964,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
       "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.22.5"
       }
@@ -15445,6 +14982,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.5.tgz",
       "integrity": "sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.22.5"
       }
@@ -15453,6 +14991,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.22.5.tgz",
       "integrity": "sha512-+hGKDt/Ze8GFExiVHno/2dvG5IdstpzCq0y4Qc9OJ25D4q3pKfiIP/4Vp3/JvhDkLKsDK2api3q3fpIgiIF5bw==",
+      "dev": true,
       "requires": {
         "@babel/helper-environment-visitor": "^7.22.5",
         "@babel/helper-module-imports": "^7.22.5",
@@ -15468,6 +15007,7 @@
           "version": "7.22.5",
           "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.5.tgz",
           "integrity": "sha512-thqK5QFghPKWLhAV321lxF95yCg2K3Ob5yw+M3VHWfdia0IkPXUtoLH8x/6Fh486QUvzhb8YOWHChTVen2/PoQ==",
+          "dev": true,
           "requires": {
             "@babel/types": "^7.22.5"
           }
@@ -15476,6 +15016,7 @@
           "version": "7.22.5",
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.5.tgz",
           "integrity": "sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==",
+          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.22.5",
             "@babel/parser": "^7.22.5",
@@ -15553,6 +15094,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
       "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.22.5"
       }
@@ -15578,17 +15120,20 @@
     "@babel/helper-string-parser": {
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw=="
+      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+      "dev": true
     },
     "@babel/helper-validator-identifier": {
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
-      "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ=="
+      "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
+      "dev": true
     },
     "@babel/helper-validator-option": {
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.5.tgz",
-      "integrity": "sha512-R3oB6xlIVKUnxNUxbmgq7pKjxpru24zlimpE8WK47fACIlM0II/Hm1RS8IaOI7NgCr6LNS+jl5l75m20npAziw=="
+      "integrity": "sha512-R3oB6xlIVKUnxNUxbmgq7pKjxpru24zlimpE8WK47fACIlM0II/Hm1RS8IaOI7NgCr6LNS+jl5l75m20npAziw==",
+      "dev": true
     },
     "@babel/helper-wrap-function": {
       "version": "7.22.5",
@@ -15619,6 +15164,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.5.tgz",
       "integrity": "sha512-pSXRmfE1vzcUIDFQcSGA5Mr+GxBV9oiRKDuDxXvWQQBCh8HoIjs/2DlDB7H8smac1IVrB9/xdXj2N3Wol9Cr+Q==",
+      "dev": true,
       "requires": {
         "@babel/template": "^7.22.5",
         "@babel/traverse": "^7.22.5",
@@ -15629,6 +15175,7 @@
           "version": "7.22.5",
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.5.tgz",
           "integrity": "sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==",
+          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.22.5",
             "@babel/parser": "^7.22.5",
@@ -15641,6 +15188,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.5.tgz",
       "integrity": "sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==",
+      "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.22.5",
         "chalk": "^2.0.0",
@@ -15650,7 +15198,8 @@
     "@babel/parser": {
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.5.tgz",
-      "integrity": "sha512-DFZMC9LJUG9PLOclRC32G63UXwzqS2koQC8dkx+PLdmt1xSePYpbT/NbsrJy8Q/muXz7o/h/d4A7Fuyixm559Q=="
+      "integrity": "sha512-DFZMC9LJUG9PLOclRC32G63UXwzqS2koQC8dkx+PLdmt1xSePYpbT/NbsrJy8Q/muXz7o/h/d4A7Fuyixm559Q==",
+      "dev": true
     },
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
       "version": "7.22.5",
@@ -16275,9 +15824,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -16431,9 +15980,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -16470,6 +16019,7 @@
       "version": "7.20.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
       "integrity": "sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.18.6",
         "@babel/parser": "^7.20.7",
@@ -16480,6 +16030,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.5.tgz",
       "integrity": "sha512-7DuIjPgERaNo6r+PZwItpjCZEa5vyw4eJGufeLxrPdBXBoLcCJCIasvK6pK/9DVNrLZTLFhUGqaC6X/PA007TQ==",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.22.5",
         "@babel/generator": "^7.22.5",
@@ -16497,6 +16048,7 @@
           "version": "7.22.5",
           "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.5.tgz",
           "integrity": "sha512-+lcUbnTRhd0jOewtFSedLyiPsD5tswKkbgcezOqqWFUVNEwoUTlpPOBmvhG7OXWLR4jMdv0czPGH5XbflnD1EA==",
+          "dev": true,
           "requires": {
             "@babel/types": "^7.22.5",
             "@jridgewell/gen-mapping": "^0.3.2",
@@ -16508,6 +16060,7 @@
           "version": "7.22.5",
           "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.5.tgz",
           "integrity": "sha512-thqK5QFghPKWLhAV321lxF95yCg2K3Ob5yw+M3VHWfdia0IkPXUtoLH8x/6Fh486QUvzhb8YOWHChTVen2/PoQ==",
+          "dev": true,
           "requires": {
             "@babel/types": "^7.22.5"
           }
@@ -16516,6 +16069,7 @@
           "version": "0.3.3",
           "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
           "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+          "dev": true,
           "requires": {
             "@jridgewell/set-array": "^1.0.1",
             "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -16528,6 +16082,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.5.tgz",
       "integrity": "sha512-zo3MIHGOkPOfoRXitsgHLjEXmlDaD/5KU1Uzuc9GNiZPhSqVxVRtxuPaSBZDsYZ9qV88AjtMtWW7ww98loJ9KA==",
+      "dev": true,
       "requires": {
         "@babel/helper-string-parser": "^7.22.5",
         "@babel/helper-validator-identifier": "^7.22.5",
@@ -16918,6 +16473,7 @@
       "version": "0.1.1",
       "resolved": "https://npm.totvs.io/@jridgewell%2fgen-mapping/-/gen-mapping-0.1.1.tgz",
       "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+      "dev": true,
       "requires": {
         "@jridgewell/set-array": "^1.0.0",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -16926,12 +16482,14 @@
     "@jridgewell/resolve-uri": {
       "version": "3.1.0",
       "resolved": "https://npm.totvs.io/@jridgewell%2fresolve-uri/-/resolve-uri-3.1.0.tgz",
-      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w=="
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true
     },
     "@jridgewell/set-array": {
       "version": "1.1.2",
       "resolved": "https://npm.totvs.io/@jridgewell%2fset-array/-/set-array-1.1.2.tgz",
-      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw=="
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true
     },
     "@jridgewell/source-map": {
       "version": "0.3.2",
@@ -16959,12 +16517,14 @@
     "@jridgewell/sourcemap-codec": {
       "version": "1.4.14",
       "resolved": "https://npm.totvs.io/@jridgewell%2fsourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
     },
     "@jridgewell/trace-mapping": {
       "version": "0.3.17",
       "resolved": "https://npm.totvs.io/@jridgewell%2ftrace-mapping/-/trace-mapping-0.3.17.tgz",
       "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+      "dev": true,
       "requires": {
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
@@ -16977,9 +16537,9 @@
       "dev": true
     },
     "@ngtools/webpack": {
-      "version": "15.2.8",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-15.2.8.tgz",
-      "integrity": "sha512-BJexeT4FxMtToVBGa3wdl6rrkYXgilP0kkSH4Qzu4MPlLPbeBSr4XQalQriewlpC2uzG0r2SJfrAe2eDhtSykA==",
+      "version": "15.2.9",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-15.2.9.tgz",
+      "integrity": "sha512-nOXUGqKkAEMlCcrhkDwWDzcVdKNH7MNRUXfNzsFc9zdeR/5p3qt6SVMN7OOE3NREyI7P6nzARc3S+6QDBjf3Jg==",
       "dev": true,
       "requires": {}
     },
@@ -17153,13 +16713,13 @@
       }
     },
     "@schematics/angular": {
-      "version": "15.2.8",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-15.2.8.tgz",
-      "integrity": "sha512-F49IEzCFxQlpaMIgTO/wF1l/CLQKif7VaiDdyiTKOeT22IMmyd61FUmWDyZYfCBqMlvBmvDGx64HaHWes1HYCg==",
+      "version": "15.2.9",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-15.2.9.tgz",
+      "integrity": "sha512-0Lit6TLNUwcAYiEkXgZp3vY9xAO1cnZCBXuUcp+6v+Ddnrt2w/YOiGe74p21cYe0StkTpTljsqsKBTiX7TMjQg==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "15.2.8",
-        "@angular-devkit/schematics": "15.2.8",
+        "@angular-devkit/core": "15.2.9",
+        "@angular-devkit/schematics": "15.2.9",
         "jsonc-parser": "3.2.0"
       }
     },
@@ -17182,7 +16742,7 @@
     },
     "@socket.io/component-emitter": {
       "version": "3.1.0",
-      "resolved": "https://npm.totvs.io/@socket.io%2fcomponent-emitter/-/component-emitter-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
       "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==",
       "dev": true
     },
@@ -17259,13 +16819,13 @@
     },
     "@types/cookie": {
       "version": "0.4.1",
-      "resolved": "https://npm.totvs.io/@types%2fcookie/-/cookie-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
       "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
       "dev": true
     },
     "@types/cors": {
       "version": "2.8.13",
-      "resolved": "https://npm.totvs.io/@types%2fcors/-/cors-2.8.13.tgz",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.13.tgz",
       "integrity": "sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==",
       "dev": true,
       "requires": {
@@ -17311,9 +16871,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.35",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.35.tgz",
-      "integrity": "sha512-wALWQwrgiB2AWTT91CB62b6Yt0sNHpznUXeZEcnPU3DRdlDIz74x8Qg1UUYKSVFi+va5vKOLYRBI1bRKiLLKIg==",
+      "version": "4.17.36",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.36.tgz",
+      "integrity": "sha512-zbivROJ0ZqLAtMzgzIUC4oNqDG9iF0lSsAqpOD9kbs5xcIM3dTiyuHvBc7R8MtWBp3AAWGaovJa+wzWPjLYW7Q==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -17321,6 +16881,12 @@
         "@types/range-parser": "*",
         "@types/send": "*"
       }
+    },
+    "@types/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-/K3ds8TRAfBvi5vfjuz8y6+GiAYBZ0x4tXv1Av6CWBWn0IlADc+ZX9pMq7oU0fNQPnBwIZl3rmeLp6SBApbxSQ==",
+      "dev": true
     },
     "@types/http-proxy": {
       "version": "1.17.11",
@@ -17355,12 +16921,14 @@
     "@types/lodash": {
       "version": "4.14.191",
       "resolved": "https://npm.totvs.io/@types%2flodash/-/lodash-4.14.191.tgz",
-      "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ=="
+      "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==",
+      "dev": true
     },
     "@types/lodash-es": {
       "version": "4.17.6",
       "resolved": "https://npm.totvs.io/@types%2flodash-es/-/lodash-es-4.17.6.tgz",
       "integrity": "sha512-R+zTeVUKDdfoRxpAryaQNRKk3105Rrgx2CFRClIgRGaqDTdjsm8h6IYA8ir584W3ePzkZfst5xIgDwYrlh9HLg==",
+      "dev": true,
       "requires": {
         "@types/lodash": "*"
       }
@@ -17433,11 +17001,12 @@
       }
     },
     "@types/serve-static": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.1.tgz",
-      "integrity": "sha512-NUo5XNiAdULrJENtJXZZ3fHtfMolzZwczzBbnAeBbqBwG+LaG6YaJtuwzwGSQZ2wsCrxjEhNNjAkKigy3n8teQ==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.2.tgz",
+      "integrity": "sha512-J2LqtvFYCzaj8pVYKw8klQXrLLk7TBZmQ4ShlcdkELFKGwGMfevMLneMMRkMgZxotOD9wg497LpC7O8PcvAmfw==",
       "dev": true,
       "requires": {
+        "@types/http-errors": "*",
         "@types/mime": "*",
         "@types/node": "*"
       }
@@ -17454,7 +17023,8 @@
     "@types/uuid": {
       "version": "9.0.0",
       "resolved": "https://npm.totvs.io/@types%2fuuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-kr90f+ERiQtKWMz5rP32ltJ/BtULDI5RVO0uavn1HQUOwjx0R1h0rnDYNL0CepF1zL5bSY6FISAfd9tOdDhU5Q=="
+      "integrity": "sha512-kr90f+ERiQtKWMz5rP32ltJ/BtULDI5RVO0uavn1HQUOwjx0R1h0rnDYNL0CepF1zL5bSY6FISAfd9tOdDhU5Q==",
+      "peer": true
     },
     "@types/ws": {
       "version": "8.5.5",
@@ -17879,7 +17449,7 @@
     },
     "accepts": {
       "version": "1.3.8",
-      "resolved": "https://npm.totvs.io/accepts/-/accepts-1.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
       "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
       "dev": true,
       "requires": {
@@ -18014,12 +17584,14 @@
     "ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://npm.totvs.io/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true
     },
     "ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://npm.totvs.io/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -18028,16 +17600,11 @@
       "version": "3.1.3",
       "resolved": "https://npm.totvs.io/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
       }
-    },
-    "app-root-path": {
-      "version": "3.1.0",
-      "resolved": "https://npm.totvs.io/app-root-path/-/app-root-path-3.1.0.tgz",
-      "integrity": "sha512-biN3PwB2gUtjaYy/isrU3aNWI5w+fAfvHkSvCKeQGxhmYpwKFUxudR3Yya+KqVRHBmEDYh+/lTozYCFbmzX4nA==",
-      "dev": true
     },
     "aproba": {
       "version": "2.0.0",
@@ -18097,12 +17664,6 @@
       "version": "1.0.1",
       "resolved": "https://npm.totvs.io/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
-    },
-    "ast-types-flow": {
-      "version": "0.0.7",
-      "resolved": "https://npm.totvs.io/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
-      "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
       "dev": true
     },
     "autoprefixer": {
@@ -18169,9 +17730,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -18198,7 +17759,8 @@
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://npm.totvs.io/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "base64-js": {
       "version": "1.5.1",
@@ -18208,7 +17770,7 @@
     },
     "base64id": {
       "version": "2.0.0",
-      "resolved": "https://npm.totvs.io/base64id/-/base64id-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
       "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
       "dev": true
     },
@@ -18227,7 +17789,8 @@
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://npm.totvs.io/binary-extensions/-/binary-extensions-2.2.0.tgz",
-      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true
     },
     "bl": {
       "version": "4.1.0",
@@ -18299,6 +17862,7 @@
       "version": "2.0.1",
       "resolved": "https://npm.totvs.io/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0"
       }
@@ -18307,6 +17871,7 @@
       "version": "3.0.2",
       "resolved": "https://npm.totvs.io/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
       "requires": {
         "fill-range": "^7.0.1"
       }
@@ -18315,6 +17880,7 @@
       "version": "4.21.5",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
       "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
+      "dev": true,
       "requires": {
         "caniuse-lite": "^1.0.30001449",
         "electron-to-chromium": "^1.4.284",
@@ -18413,12 +17979,14 @@
     "caniuse-lite": {
       "version": "1.0.30001506",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001506.tgz",
-      "integrity": "sha512-6XNEcpygZMCKaufIcgpQNZNf00GEqc7VQON+9Rd0K1bMYo8xhMZRAo5zpbnbMNizi4YNgIDAFrdykWsvY3H4Hw=="
+      "integrity": "sha512-6XNEcpygZMCKaufIcgpQNZNf00GEqc7VQON+9Rd0K1bMYo8xhMZRAo5zpbnbMNizi4YNgIDAFrdykWsvY3H4Hw==",
+      "dev": true
     },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://npm.totvs.io/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -18435,6 +18003,7 @@
       "version": "3.5.3",
       "resolved": "https://npm.totvs.io/chokidar/-/chokidar-3.5.3.tgz",
       "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
       "requires": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -18513,100 +18082,11 @@
         "shallow-clone": "^3.0.0"
       }
     },
-    "codelyzer": {
-      "version": "6.0.2",
-      "resolved": "https://npm.totvs.io/codelyzer/-/codelyzer-6.0.2.tgz",
-      "integrity": "sha512-v3+E0Ucu2xWJMOJ2fA/q9pDT/hlxHftHGPUay1/1cTgyPV5JTHFdO9hqo837Sx2s9vKBMTt5gO+lhF95PO6J+g==",
-      "dev": true,
-      "requires": {
-        "@angular/compiler": "9.0.0",
-        "@angular/core": "9.0.0",
-        "app-root-path": "^3.0.0",
-        "aria-query": "^3.0.0",
-        "axobject-query": "2.0.2",
-        "css-selector-tokenizer": "^0.7.1",
-        "cssauron": "^1.4.0",
-        "damerau-levenshtein": "^1.0.4",
-        "rxjs": "^6.5.3",
-        "semver-dsl": "^1.0.1",
-        "source-map": "^0.5.7",
-        "sprintf-js": "^1.1.2",
-        "tslib": "^1.10.0",
-        "zone.js": "~0.10.3"
-      },
-      "dependencies": {
-        "@angular/compiler": {
-          "version": "9.0.0",
-          "resolved": "https://npm.totvs.io/@angular%2fcompiler/-/compiler-9.0.0.tgz",
-          "integrity": "sha512-ctjwuntPfZZT2mNj2NDIVu51t9cvbhl/16epc5xEwyzyDt76pX9UgwvY+MbXrf/C/FWwdtmNtfP698BKI+9leQ==",
-          "dev": true,
-          "requires": {}
-        },
-        "@angular/core": {
-          "version": "9.0.0",
-          "resolved": "https://npm.totvs.io/@angular%2fcore/-/core-9.0.0.tgz",
-          "integrity": "sha512-6Pxgsrf0qF9iFFqmIcWmjJGkkCaCm6V5QNnxMy2KloO3SDq6QuMVRbN9RtC8Urmo25LP+eZ6ZgYqFYpdD8Hd9w==",
-          "dev": true,
-          "requires": {}
-        },
-        "aria-query": {
-          "version": "3.0.0",
-          "resolved": "https://npm.totvs.io/aria-query/-/aria-query-3.0.0.tgz",
-          "integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
-          "dev": true,
-          "requires": {
-            "ast-types-flow": "0.0.7",
-            "commander": "^2.11.0"
-          }
-        },
-        "axobject-query": {
-          "version": "2.0.2",
-          "resolved": "https://npm.totvs.io/axobject-query/-/axobject-query-2.0.2.tgz",
-          "integrity": "sha512-MCeek8ZH7hKyO1rWUbKNQBbl4l2eY0ntk7OGi+q0RlafrCnfPxC06WZA+uebCfmYp4mNU9jRBP1AhGyf8+W3ww==",
-          "dev": true,
-          "requires": {
-            "ast-types-flow": "0.0.7"
-          }
-        },
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://npm.totvs.io/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true
-        },
-        "rxjs": {
-          "version": "6.6.7",
-          "resolved": "https://npm.totvs.io/rxjs/-/rxjs-6.6.7.tgz",
-          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
-          "dev": true,
-          "requires": {
-            "tslib": "^1.9.0"
-          }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://npm.totvs.io/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        },
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://npm.totvs.io/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
-        },
-        "zone.js": {
-          "version": "0.10.3",
-          "resolved": "https://npm.totvs.io/zone.js/-/zone.js-0.10.3.tgz",
-          "integrity": "sha512-LXVLVEq0NNOqK/fLJo3d0kfzd4sxwn2/h67/02pjCjfKDxgx1i9QqpvtHD8CrBnSSwMw5+dy11O7FRX5mkO7Cg==",
-          "dev": true
-        }
-      }
-    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://npm.totvs.io/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -18614,7 +18094,8 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://npm.totvs.io/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
     },
     "color-support": {
       "version": "1.1.3",
@@ -18758,11 +18239,12 @@
     "convert-source-map": {
       "version": "1.9.0",
       "resolved": "https://npm.totvs.io/convert-source-map/-/convert-source-map-1.9.0.tgz",
-      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "dev": true
     },
     "cookie": {
       "version": "0.4.2",
-      "resolved": "https://npm.totvs.io/cookie/-/cookie-0.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
       "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
       "dev": true
     },
@@ -18828,7 +18310,8 @@
     "core-js": {
       "version": "2.6.10",
       "resolved": "https://npm.totvs.io/core-js/-/core-js-2.6.10.tgz",
-      "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+      "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==",
+      "dev": true
     },
     "core-js-compat": {
       "version": "3.31.0",
@@ -18847,7 +18330,7 @@
     },
     "cors": {
       "version": "2.8.5",
-      "resolved": "https://npm.totvs.io/cors/-/cors-2.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
       "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
       "dev": true,
       "requires": {
@@ -18973,30 +18456,11 @@
         "nth-check": "^2.0.1"
       }
     },
-    "css-selector-tokenizer": {
-      "version": "0.7.3",
-      "resolved": "https://npm.totvs.io/css-selector-tokenizer/-/css-selector-tokenizer-0.7.3.tgz",
-      "integrity": "sha512-jWQv3oCEL5kMErj4wRnK/OPoBi0D+P1FR2cDCKYPaMeD2eW3/mttav8HT4hT1CKopiJI/psEULjkClhvJo4Lvg==",
-      "dev": true,
-      "requires": {
-        "cssesc": "^3.0.0",
-        "fastparse": "^1.1.2"
-      }
-    },
     "css-what": {
       "version": "6.1.0",
       "resolved": "https://npm.totvs.io/css-what/-/css-what-6.1.0.tgz",
       "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
       "dev": true
-    },
-    "cssauron": {
-      "version": "1.4.0",
-      "resolved": "https://npm.totvs.io/cssauron/-/cssauron-1.4.0.tgz",
-      "integrity": "sha1-pmAt/34EqDBtwNuaVR6S6LVmKtg=",
-      "dev": true,
-      "requires": {
-        "through": "X.X.X"
-      }
     },
     "cssesc": {
       "version": "3.0.0",
@@ -19016,12 +18480,6 @@
       "integrity": "sha1-XQKkaFCt8bSjF5RqOSj8y1v9BCU=",
       "dev": true
     },
-    "damerau-levenshtein": {
-      "version": "1.0.8",
-      "resolved": "https://npm.totvs.io/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
-      "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
-      "dev": true
-    },
     "date-format": {
       "version": "4.0.14",
       "resolved": "https://npm.totvs.io/date-format/-/date-format-4.0.14.tgz",
@@ -19032,6 +18490,7 @@
       "version": "4.3.4",
       "resolved": "https://npm.totvs.io/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -19120,7 +18579,8 @@
     "dependency-graph": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.11.0.tgz",
-      "integrity": "sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg=="
+      "integrity": "sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==",
+      "dev": true
     },
     "destroy": {
       "version": "1.2.0",
@@ -19162,9 +18622,9 @@
       "dev": true
     },
     "dns-packet": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.0.tgz",
-      "integrity": "sha512-rza3UH1LwdHh9qyPXp8lkwpjSNk/AMD3dPytUoRoqnypDUhY0xvbdmVhWOfxO68frEfV9BU8V12Ez7ZsHGZpCQ==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
+      "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
       "dev": true,
       "requires": {
         "@leichtgewicht/ip-codec": "^2.0.1"
@@ -19243,12 +18703,14 @@
     "electron-to-chromium": {
       "version": "1.4.284",
       "resolved": "https://npm.totvs.io/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
-      "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA=="
+      "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
+      "dev": true
     },
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://npm.totvs.io/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
     },
     "emojis-list": {
       "version": "3.0.0",
@@ -19285,9 +18747,9 @@
       }
     },
     "engine.io": {
-      "version": "6.2.1",
-      "resolved": "https://npm.totvs.io/engine.io/-/engine.io-6.2.1.tgz",
-      "integrity": "sha512-ECceEFcAaNRybd3lsGQKas3ZlMVjN3cyWwMP25D2i0zWfyiytVbTpRPa34qrr+FHddtpBVOmq4H/DCv1O0lZRA==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.2.tgz",
+      "integrity": "sha512-IXsMcGpw/xRfjra46sVZVHiSWo/nJ/3g1337q9KNXtS6YRzbW5yIzTCb9DjhrBe7r3GZQR0I4+nq+4ODk5g/cA==",
       "dev": true,
       "requires": {
         "@types/cookie": "^0.4.1",
@@ -19298,14 +18760,14 @@
         "cookie": "~0.4.1",
         "cors": "~2.8.5",
         "debug": "~4.3.1",
-        "engine.io-parser": "~5.0.3",
-        "ws": "~8.2.3"
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.11.0"
       }
     },
     "engine.io-parser": {
-      "version": "5.0.4",
-      "resolved": "https://npm.totvs.io/engine.io-parser/-/engine.io-parser-5.0.4.tgz",
-      "integrity": "sha512-+nVFp+5z1E3HcToEnO7ZIj3g+3k9389DvWtvJZz0T6/eOCPIyyxehFcedoYrZQrp0LgQbD9pPXhpMBKMd5QURg==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.1.tgz",
+      "integrity": "sha512-9JktcM3u18nU9N2Lz3bWeBgxVgOKpw7yhRaoxQA3FUDZzzw+9WlA6p4G4u0RixNkg14fH7EfEc/RhpurtiROTQ==",
       "dev": true
     },
     "enhanced-resolve": {
@@ -19423,7 +18885,8 @@
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://npm.totvs.io/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true
     },
     "escape-html": {
       "version": "1.0.3",
@@ -19434,7 +18897,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://npm.totvs.io/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "eslint": {
       "version": "8.30.0",
@@ -19934,12 +19398,6 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
-    "fastparse": {
-      "version": "1.1.2",
-      "resolved": "https://npm.totvs.io/fastparse/-/fastparse-1.1.2.tgz",
-      "integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==",
-      "dev": true
-    },
     "fastq": {
       "version": "1.14.0",
       "resolved": "https://npm.totvs.io/fastq/-/fastq-1.14.0.tgz",
@@ -19980,6 +19438,7 @@
       "version": "7.0.1",
       "resolved": "https://npm.totvs.io/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
       }
@@ -20139,12 +19598,14 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://npm.totvs.io/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "fsevents": {
       "version": "2.3.2",
       "resolved": "https://npm.totvs.io/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "optional": true
     },
     "function-bind": {
@@ -20178,12 +19639,14 @@
     "gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://npm.totvs.io/gensync/-/gensync-1.0.0-beta.2.tgz",
-      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true
     },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://npm.totvs.io/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
     },
     "get-intrinsic": {
       "version": "1.1.3",
@@ -20212,6 +19675,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
       "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -20224,6 +19688,7 @@
       "version": "5.1.2",
       "resolved": "https://npm.totvs.io/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
       }
@@ -20237,7 +19702,8 @@
     "globals": {
       "version": "11.12.0",
       "resolved": "https://npm.totvs.io/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true
     },
     "globby": {
       "version": "11.1.0",
@@ -20298,7 +19764,8 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://npm.totvs.io/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
     },
     "has-property-descriptors": {
       "version": "1.0.0",
@@ -20415,9 +19882,9 @@
       }
     },
     "html-entities": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.6.tgz",
-      "integrity": "sha512-9o0+dcpIw2/HxkNuYKxSJUF/MMRZQECK4GnF+oQOmJ83yCVHTWgCH5aOXxK5bozNRmM8wtgryjHD3uloPBDEGw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.4.0.tgz",
+      "integrity": "sha512-igBTJcNNNhvZFRtm8uA6xMY6xYleeDwn3PeBCkDz7tHttv4F2hsDI2aPgNERWzvRcNYHNT3ymRaQzllmXj4YsQ==",
       "dev": true
     },
     "html-escaper": {
@@ -20620,6 +20087,7 @@
       "version": "1.0.6",
       "resolved": "https://npm.totvs.io/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -20628,7 +20096,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://npm.totvs.io/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "ini": {
       "version": "3.0.1",
@@ -20760,6 +20229,7 @@
       "version": "2.1.0",
       "resolved": "https://npm.totvs.io/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
       "requires": {
         "binary-extensions": "^2.0.0"
       }
@@ -20816,17 +20286,20 @@
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://npm.totvs.io/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://npm.totvs.io/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true
     },
     "is-glob": {
       "version": "4.0.3",
       "resolved": "https://npm.totvs.io/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
       }
@@ -20858,7 +20331,8 @@
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://npm.totvs.io/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
     },
     "is-number-object": {
       "version": "1.0.7",
@@ -21024,9 +20498,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://npm.totvs.io/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -21147,7 +20621,8 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.14.1",
@@ -21162,7 +20637,8 @@
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://npm.totvs.io/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
     },
     "json-parse-even-better-errors": {
       "version": "2.3.1",
@@ -21190,7 +20666,8 @@
     "json5": {
       "version": "2.2.2",
       "resolved": "https://npm.totvs.io/json5/-/json5-2.2.2.tgz",
-      "integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ=="
+      "integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ==",
+      "dev": true
     },
     "jsonc-parser": {
       "version": "3.2.0",
@@ -21436,9 +20913,9 @@
           "optional": true
         },
         "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
           "dev": true,
           "optional": true
         },
@@ -21602,6 +21079,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
       "requires": {
         "yallist": "^3.0.2"
       },
@@ -21609,7 +21087,8 @@
         "yallist": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+          "dev": true
         }
       }
     },
@@ -21632,9 +21111,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://npm.totvs.io/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -21777,6 +21256,7 @@
       "version": "5.1.0",
       "resolved": "https://npm.totvs.io/minimatch/-/minimatch-5.1.0.tgz",
       "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^2.0.1"
       }
@@ -21944,7 +21424,8 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://npm.totvs.io/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "multicast-dns": {
       "version": "7.2.5",
@@ -22155,7 +21636,8 @@
     "node-releases": {
       "version": "2.0.8",
       "resolved": "https://npm.totvs.io/node-releases/-/node-releases-2.0.8.tgz",
-      "integrity": "sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A=="
+      "integrity": "sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A==",
+      "dev": true
     },
     "nopt": {
       "version": "6.0.0",
@@ -22181,7 +21663,8 @@
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://npm.totvs.io/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
     },
     "normalize-range": {
       "version": "0.1.2",
@@ -22301,8 +21784,8 @@
     },
     "object-assign": {
       "version": "4.1.1",
-      "resolved": "https://npm.totvs.io/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "dev": true
     },
     "object-inspect": {
@@ -22364,6 +21847,7 @@
       "version": "1.4.0",
       "resolved": "https://npm.totvs.io/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -22724,12 +22208,14 @@
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://npm.totvs.io/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
     },
     "picomatch": {
       "version": "2.3.1",
       "resolved": "https://npm.totvs.io/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true
     },
     "pify": {
       "version": "4.0.1",
@@ -23072,6 +22558,7 @@
       "version": "3.6.0",
       "resolved": "https://npm.totvs.io/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
       "requires": {
         "picomatch": "^2.2.1"
       }
@@ -23079,7 +22566,8 @@
     "reflect-metadata": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
-      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==",
+      "dev": true
     },
     "regenerate": {
       "version": "1.4.2",
@@ -23168,7 +22656,8 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://npm.totvs.io/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
     },
     "require-from-string": {
       "version": "2.0.2",
@@ -23403,9 +22892,10 @@
       }
     },
     "semver": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
-      "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+      "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
       },
@@ -23414,26 +22904,10 @@
           "version": "6.0.0",
           "resolved": "https://npm.totvs.io/lru-cache/-/lru-cache-6.0.0.tgz",
           "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
           "requires": {
             "yallist": "^4.0.0"
           }
-        }
-      }
-    },
-    "semver-dsl": {
-      "version": "1.0.1",
-      "resolved": "https://npm.totvs.io/semver-dsl/-/semver-dsl-1.0.1.tgz",
-      "integrity": "sha1-02eN5VVeimH2Ke7QJTZq5fJzQKA=",
-      "dev": true,
-      "requires": {
-        "semver": "^5.3.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://npm.totvs.io/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
         }
       }
     },
@@ -23656,29 +23130,33 @@
       "dev": true
     },
     "socket.io": {
-      "version": "4.5.4",
-      "resolved": "https://npm.totvs.io/socket.io/-/socket.io-4.5.4.tgz",
-      "integrity": "sha512-m3GC94iK9MfIEeIBfbhJs5BqFibMtkRk8ZpKwG2QwxV0m/eEhPIV4ara6XCF1LWNAus7z58RodiZlAH71U3EhQ==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.2.tgz",
+      "integrity": "sha512-bvKVS29/I5fl2FGLNHuXlQaUH/BlzX1IN6S+NKLNZpBsPZIDH+90eQmCs2Railn4YUiww4SzUedJ6+uzwFnKLw==",
       "dev": true,
       "requires": {
         "accepts": "~1.3.4",
         "base64id": "~2.0.0",
+        "cors": "~2.8.5",
         "debug": "~4.3.2",
-        "engine.io": "~6.2.1",
-        "socket.io-adapter": "~2.4.0",
-        "socket.io-parser": "~4.2.1"
+        "engine.io": "~6.5.2",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
       }
     },
     "socket.io-adapter": {
-      "version": "2.4.0",
-      "resolved": "https://npm.totvs.io/socket.io-adapter/-/socket.io-adapter-2.4.0.tgz",
-      "integrity": "sha512-W4N+o69rkMEGVuk2D/cvca3uYsvGlMwsySWV447y99gUPghxq42BxqLNMndb+a1mm/5/7NeXVQS7RLa2XyXvYg==",
-      "dev": true
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.2.tgz",
+      "integrity": "sha512-87C3LO/NOMc+eMcpcxUBebGjkpMDkNBS9tf7KJqcDsmL936EChtVva71Dw2q4tQcuVC+hAUy4an2NO/sYXmwRA==",
+      "dev": true,
+      "requires": {
+        "ws": "~8.11.0"
+      }
     },
     "socket.io-parser": {
-      "version": "4.2.1",
-      "resolved": "https://npm.totvs.io/socket.io-parser/-/socket.io-parser-4.2.1.tgz",
-      "integrity": "sha512-V4GrkLy+HeF1F/en3SpUaM+7XxYXpuMUWLGde1kSSh5nQMN4hLrbPIkD+otwh6q9R6NOQBN4AMaOZ2zVjui82g==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
       "dev": true,
       "requires": {
         "@socket.io/component-emitter": "~3.1.0",
@@ -23836,12 +23314,6 @@
         "wbuf": "^1.7.3"
       }
     },
-    "sprintf-js": {
-      "version": "1.1.2",
-      "resolved": "https://npm.totvs.io/sprintf-js/-/sprintf-js-1.1.2.tgz",
-      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
-      "dev": true
-    },
     "ssri": {
       "version": "10.0.4",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.4.tgz",
@@ -23917,6 +23389,7 @@
       "version": "4.2.3",
       "resolved": "https://npm.totvs.io/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -23938,6 +23411,7 @@
       "version": "6.0.1",
       "resolved": "https://npm.totvs.io/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "requires": {
         "ansi-regex": "^5.0.1"
       }
@@ -23967,6 +23441,7 @@
       "version": "5.5.0",
       "resolved": "https://npm.totvs.io/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -24178,12 +23653,14 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://npm.totvs.io/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
     },
     "to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://npm.totvs.io/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
       "requires": {
         "is-number": "^7.0.0"
       }
@@ -24231,121 +23708,6 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-    },
-    "tslint": {
-      "version": "6.1.3",
-      "resolved": "https://npm.totvs.io/tslint/-/tslint-6.1.3.tgz",
-      "integrity": "sha512-IbR4nkT96EQOvKE2PW/djGz8iGNeJ4rF2mBfiYaR/nvUWYKJhLwimoJKgjIFEIDibBtOevj7BqCRL4oHeWWUCg==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "builtin-modules": "^1.1.1",
-        "chalk": "^2.3.0",
-        "commander": "^2.12.1",
-        "diff": "^4.0.1",
-        "glob": "^7.1.1",
-        "js-yaml": "^3.13.1",
-        "minimatch": "^3.0.4",
-        "mkdirp": "^0.5.3",
-        "resolve": "^1.3.2",
-        "semver": "^5.3.0",
-        "tslib": "^1.13.0",
-        "tsutils": "^2.29.0"
-      },
-      "dependencies": {
-        "brace-expansion": {
-          "version": "1.1.11",
-          "resolved": "https://npm.totvs.io/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "builtin-modules": {
-          "version": "1.1.1",
-          "resolved": "https://npm.totvs.io/builtin-modules/-/builtin-modules-1.1.1.tgz",
-          "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-          "dev": true,
-          "peer": true
-        },
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://npm.totvs.io/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true,
-          "peer": true
-        },
-        "diff": {
-          "version": "4.0.2",
-          "resolved": "https://npm.totvs.io/diff/-/diff-4.0.2.tgz",
-          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-          "dev": true,
-          "peer": true
-        },
-        "glob": {
-          "version": "7.2.3",
-          "resolved": "https://npm.totvs.io/glob/-/glob-7.2.3.tgz",
-          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.1.1",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "minimatch": {
-          "version": "3.1.2",
-          "resolved": "https://npm.totvs.io/minimatch/-/minimatch-3.1.2.tgz",
-          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.6",
-          "resolved": "https://npm.totvs.io/mkdirp/-/mkdirp-0.5.6.tgz",
-          "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "minimist": "^1.2.6"
-          }
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://npm.totvs.io/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true,
-          "peer": true
-        },
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://npm.totvs.io/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true,
-          "peer": true
-        },
-        "tsutils": {
-          "version": "2.29.0",
-          "resolved": "https://npm.totvs.io/tsutils/-/tsutils-2.29.0.tgz",
-          "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "tslib": "^1.8.1"
-          }
-        }
-      }
     },
     "tsutils": {
       "version": "3.21.0",
@@ -24409,12 +23771,13 @@
     "typescript": {
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true
     },
     "ua-parser-js": {
-      "version": "0.7.32",
-      "resolved": "https://npm.totvs.io/ua-parser-js/-/ua-parser-js-0.7.32.tgz",
-      "integrity": "sha512-f9BESNVhzlhEFf2CHMSj40NWOjYPl1YKYbrvIr/hFTDEmLq7SRbWvm7FcdcpCYT95zrOhC7gZSxjdnnTpBcwVw==",
+      "version": "0.7.35",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.35.tgz",
+      "integrity": "sha512-veRf7dawaj9xaWEu9HoTVn5Pggtc/qj+kqTOFvNiN1l0YdxwC1kvel57UCjThjGa3BHBihE8/UJAHI+uQHmd/g==",
       "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {
@@ -24473,6 +23836,7 @@
       "version": "1.0.10",
       "resolved": "https://npm.totvs.io/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
       "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+      "dev": true,
       "requires": {
         "escalade": "^3.1.1",
         "picocolors": "^1.0.0"
@@ -24525,8 +23889,8 @@
     },
     "vary": {
       "version": "1.1.2",
-      "resolved": "https://npm.totvs.io/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "dev": true
     },
     "void-elements": {
@@ -24717,13 +24081,6 @@
             "range-parser": "^1.2.1",
             "schema-utils": "^4.0.0"
           }
-        },
-        "ws": {
-          "version": "8.13.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-          "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-          "dev": true,
-          "requires": {}
         }
       }
     },
@@ -24833,15 +24190,16 @@
       "dev": true
     },
     "word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://npm.totvs.io/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true
     },
     "wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://npm.totvs.io/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -24852,6 +24210,7 @@
           "version": "4.3.0",
           "resolved": "https://npm.totvs.io/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
@@ -24860,6 +24219,7 @@
           "version": "2.0.1",
           "resolved": "https://npm.totvs.io/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -24867,7 +24227,8 @@
         "color-name": {
           "version": "1.1.4",
           "resolved": "https://npm.totvs.io/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
         }
       }
     },
@@ -24911,12 +24272,13 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://npm.totvs.io/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "ws": {
-      "version": "8.2.3",
-      "resolved": "https://npm.totvs.io/ws/-/ws-8.2.3.tgz",
-      "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
       "dev": true,
       "requires": {}
     },
@@ -24932,12 +24294,14 @@
     "y18n": {
       "version": "5.0.8",
       "resolved": "https://npm.totvs.io/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true
     },
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://npm.totvs.io/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "yaml": {
       "version": "1.10.2",
@@ -24949,6 +24313,7 @@
       "version": "17.6.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
       "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+      "dev": true,
       "requires": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -24963,6 +24328,7 @@
           "version": "8.0.1",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
           "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+          "dev": true,
           "requires": {
             "string-width": "^4.2.0",
             "strip-ansi": "^6.0.1",
@@ -24972,7 +24338,8 @@
         "yargs-parser": {
           "version": "21.1.1",
           "resolved": "https://npm.totvs.io/yargs-parser/-/yargs-parser-21.1.1.tgz",
-          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+          "dev": true
         }
       }
     },
@@ -24992,6 +24359,8 @@
       "version": "0.11.8",
       "resolved": "https://npm.totvs.io/zone.js/-/zone.js-0.11.8.tgz",
       "integrity": "sha512-82bctBg2hKcEJ21humWIkXRlLBBmrc3nN7DFh5LGGhcyycO2S7FN8NmdvlcKaGFDNVL4/9kFLmwmInTavdJERA==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "tslib": "^2.3.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-backend-api",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "private": false,
   "description": "API para simular um backend em memoria para ser usado em aplicações angular",
   "readmeFilename": "README.md",
@@ -34,23 +34,15 @@
     "lint": "ng lint web-backend-api"
   },
   "dependencies": {
-    "@angular/animations": "15.2.9",
-    "@angular/common": "15.2.9",
-    "@angular/compiler": "15.2.9",
-    "@angular/core": "15.2.9",
-    "@angular/forms": "15.2.9",
-    "@angular/localize": "^15.2.9",
-    "@angular/platform-browser": "15.2.9",
-    "@angular/platform-browser-dynamic": "15.2.9",
-    "@angular/router": "15.2.9",
-    "@types/lodash-es": "^4.17.6",
-    "@types/uuid": "^9.0.0",
-    "core-js": "2.6.10",
     "json.date-extensions": "^1.2.2",
-    "rxjs": "^7.4.0",
     "tslib": "^2.0.0",
-    "uuid": "^9.0.0",
-    "zone.js": "~0.11.4"
+    "uuid": "^9.0.0"
+  },
+  "peerDependencies": {
+    "@angular/common": "13 - 15",
+    "@angular/core": "13 - 15",
+    "@types/uuid": "^9.0.0",
+    "rxjs": "^7.4.0"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^15.2.8",
@@ -61,14 +53,18 @@
     "@angular-eslint/schematics": "^15.2.1",
     "@angular-eslint/template-parser": "15.2.1",
     "@angular/cli": "^15.2.8",
+    "@angular/common": "^15.2.0",
+    "@angular/compiler": "^15.2.0",
     "@angular/compiler-cli": "^15.2.9",
+    "@angular/core": "^15.2.0",
     "@angular/language-service": "^15.2.9",
     "@types/jasmine": "~3.6.0",
     "@types/jasminewd2": "~2.0.3",
+    "@types/lodash-es": "^4.17.6",
     "@types/node": "^12.11.1",
     "@typescript-eslint/eslint-plugin": "^5.46.1",
     "@typescript-eslint/parser": "^5.46.1",
-    "codelyzer": "^6.0.0",
+    "core-js": "2.6.10",
     "eslint": "^8.2.0",
     "jasmine-core": "^4.5.0",
     "jasmine-data-provider-ts": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -34,15 +34,10 @@
     "lint": "ng lint web-backend-api"
   },
   "dependencies": {
+    "clonedeep": "^2.0.0",
     "json.date-extensions": "^1.2.2",
     "tslib": "^2.0.0",
     "uuid": "^9.0.0"
-  },
-  "peerDependencies": {
-    "@angular/common": "13 - 15",
-    "@angular/core": "13 - 15",
-    "@types/uuid": "^9.0.0",
-    "rxjs": "^7.4.0"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^15.2.8",
@@ -60,7 +55,6 @@
     "@angular/language-service": "^15.2.9",
     "@types/jasmine": "~3.6.0",
     "@types/jasminewd2": "~2.0.3",
-    "@types/lodash-es": "^4.17.6",
     "@types/node": "^12.11.1",
     "@typescript-eslint/eslint-plugin": "^5.46.1",
     "@typescript-eslint/parser": "^5.46.1",

--- a/src/angular/src/http-client-backend.service.ts
+++ b/src/angular/src/http-client-backend.service.ts
@@ -3,7 +3,7 @@ import { XhrFactory } from '@angular/common';
 import { HttpBackend, HttpErrorResponse, HttpEvent, HttpHeaders, HttpRequest, HttpResponse, HttpXhrBackend } from '@angular/common/http';
 import { Inject, Injectable, InjectionToken, Optional } from '@angular/core';
 import { ErrorResponseFn, getStatusText, IBackendService, IErrorMessage, IPassThruBackend, ResponseFn, STATUS } from '../../database';
-import { Observable, throwError } from 'rxjs';
+import { Observable, from, throwError } from 'rxjs';
 
 export const BACKEND_SERVICE = new InjectionToken<IBackendService>('backend.service');
 
@@ -23,8 +23,7 @@ export class HttpClientBackendService implements HttpBackend {
 
   handle(req: HttpRequest<unknown>): Observable<HttpEvent<unknown>> {
     try {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return this.dbService.handleRequest(req) as any;
+      return from(this.dbService.handleRequest<HttpEvent<unknown>>(req));
     } catch (error) {
       const err: unknown = (error as Error).message || error;
       const resOptions = this.createErrorResponseOptions(req.url, STATUS.INTERNAL_SERVER_ERROR, err);

--- a/src/angular/src/http-client-backend.service.ts
+++ b/src/angular/src/http-client-backend.service.ts
@@ -1,9 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unsafe-return */
-import { XhrFactory } from '@angular/common';
-import { HttpBackend, HttpErrorResponse, HttpEvent, HttpHeaders, HttpRequest, HttpResponse, HttpXhrBackend } from '@angular/common/http';
+import { HttpBackend, HttpErrorResponse, HttpEvent, HttpHeaders, HttpRequest, HttpResponse } from '@angular/common/http';
 import { Inject, Injectable, InjectionToken, Optional } from '@angular/core';
-import { ErrorResponseFn, getStatusText, IBackendService, IErrorMessage, IPassThruBackend, ResponseFn, STATUS } from '../../database';
 import { Observable, from, throwError } from 'rxjs';
+import { ErrorResponseFn, IBackendService, IErrorMessage, ResponseFn, STATUS, getStatusText } from '../../database';
 
 export const BACKEND_SERVICE = new InjectionToken<IBackendService>('backend.service');
 
@@ -11,11 +10,10 @@ export const BACKEND_SERVICE = new InjectionToken<IBackendService>('backend.serv
 export class HttpClientBackendService implements HttpBackend {
 
   constructor(
-    @Inject(BACKEND_SERVICE) @Optional() private dbService: IBackendService,
-    private xhrFactory: XhrFactory
+    @Inject(BACKEND_SERVICE) @Optional() private dbService: IBackendService
   ) {
     this.dbService.backendUtils({
-      createPassThruBackend: this.createPassThruBackend.bind(this) as () => IPassThruBackend,
+      createPassThruBackend: () => this.dbService.createFetchBackend(),
       createResponseOptions: this.createResponseOptions.bind(this) as ResponseFn,
       createErrorResponseOptions: this.createErrorResponseOptions.bind(this) as ErrorResponseFn
     });
@@ -27,17 +25,7 @@ export class HttpClientBackendService implements HttpBackend {
     } catch (error) {
       const err: unknown = (error as Error).message || error;
       const resOptions = this.createErrorResponseOptions(req.url, STATUS.INTERNAL_SERVER_ERROR, err);
-      return throwError(resOptions);
-    }
-  }
-
-  private createPassThruBackend(): IPassThruBackend {
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return new HttpXhrBackend(this.xhrFactory) as any;
-    } catch (ex) {
-      (ex as Error).message = `Cannot create passThru404 backend; ${(ex as Error).message || ''}`;
-      throw ex;
+      return throwError(() => resOptions);
     }
   }
 

--- a/src/angular/src/web-backend-api.module.ts
+++ b/src/angular/src/web-backend-api.module.ts
@@ -1,16 +1,14 @@
 
-import { XhrFactory } from '@angular/common';
 import { HttpBackend } from '@angular/common/http';
 import { ModuleWithProviders, NgModule } from '@angular/core';
-import { getBackendService, IBackendService } from '../../database';
+import { IBackendService, getBackendService } from '../../database';
 import { DownloadDataService } from './download-data.service';
 import { BACKEND_SERVICE, HttpClientBackendService } from './http-client-backend.service';
 
-export function httpClientBackendServiceFactory(
+function httpClientBackendServiceFactory(
   dbService: IBackendService,
-  xhrFactory: XhrFactory,
 ): HttpBackend {
-  return new HttpClientBackendService(dbService, xhrFactory);
+  return new HttpClientBackendService(dbService);
 }
 
 @NgModule({})
@@ -23,7 +21,7 @@ export class WebBackendApiModule {
         { provide: BACKEND_SERVICE, useFactory: getBackendService },
         { provide: HttpBackend,
           useFactory: httpClientBackendServiceFactory,
-          deps: [BACKEND_SERVICE, XhrFactory]
+          deps: [BACKEND_SERVICE]
         },
         DownloadDataService,
       ]

--- a/src/angular/testing/src/http-client-testing-backend.service.ts
+++ b/src/angular/testing/src/http-client-testing-backend.service.ts
@@ -1,11 +1,10 @@
 /* eslint-disable @typescript-eslint/no-unsafe-return */
-import { XhrFactory } from '@angular/common';
 import { HttpErrorResponse, HttpEvent, HttpRequest, HttpResponse } from '@angular/common/http';
 import { RequestMatch } from '@angular/common/http/testing';
 import { Inject, Injectable, Optional } from '@angular/core';
-import { IBackendService } from '../../../database';
 import { Observable, throwError } from 'rxjs';
 import { catchError, tap } from 'rxjs/operators';
+import { IBackendService } from '../../../database';
 import { BACKEND_SERVICE, HttpClientBackendService } from '../../src/http-client-backend.service';
 
 export interface IRequestResponse {
@@ -25,9 +24,9 @@ export class HttpClientTestingBackendService extends HttpClientBackendService {
   private requests: IRequestResponse[] = [];
 
   constructor(
-    @Inject(BACKEND_SERVICE) @Optional() dbService: IBackendService, xhrFactory: XhrFactory
+    @Inject(BACKEND_SERVICE) @Optional() dbService: IBackendService
   ) {
-    super(dbService, xhrFactory);
+    super(dbService);
   }
 
   handle(request: HttpRequest<unknown>): Observable<HttpEvent<unknown>> {

--- a/src/angular/testing/src/web-backend-api-testing.module.ts
+++ b/src/angular/testing/src/web-backend-api-testing.module.ts
@@ -1,16 +1,15 @@
 
 import { HttpBackend } from '@angular/common/http';
 import { ModuleWithProviders, NgModule } from '@angular/core';
-import { getBackendService } from '../../../database';
+import { IBackendService, getBackendService } from '../../../database';
 import { BACKEND_SERVICE } from '../../src/http-client-backend.service';
 import { HttpClientTestingBackendService } from './http-client-testing-backend.service';
 
-// export function httpClientBackendServiceFactory(
-//   dbService: IBackendService,
-//   xhrFactory: XhrFactory,
-// ): HttpBackend {
-//   return new HttpClientTestingBackendService(dbService, xhrFactory);
-// }
+export function httpClientBackendServiceFactory(
+  dbService: IBackendService
+): HttpBackend {
+  return new HttpClientTestingBackendService(dbService);
+}
 
 @NgModule({})
 export class WebBackendApiTestingModule {
@@ -24,11 +23,11 @@ export class WebBackendApiTestingModule {
           provide: BACKEND_SERVICE,
           useFactory: getBackendService
         },
-        // {
-        //   provide: HttpClientTestingBackendService,
-        //   // useFactory: httpClientBackendServiceFactory,
-        //   deps: [BACKEND_SERVICE, XhrFactory]
-        // },
+        {
+          provide: HttpClientTestingBackendService,
+          useFactory: httpClientBackendServiceFactory,
+          deps: [BACKEND_SERVICE]
+        },
         {
           provide: HttpBackend,
           useExisting: HttpClientTestingBackendService

--- a/src/database/src/data-service/backend.service.ts
+++ b/src/database/src/data-service/backend.service.ts
@@ -1,6 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unsafe-argument */
-import { BehaviorSubject, Observable, Subscriber, throwError } from 'rxjs';
-import { catchError, concatMap, first, map, tap } from 'rxjs/operators';
+import { Observable, firstValueFrom } from 'rxjs';
 import { IBackendUtils, IJoinField, LoadFn, TransformGetFn, TransformPostFn, TransformPutFn } from '../interfaces/backend.interface';
 import { BackendConfigArgs } from '../interfaces/configuration.interface';
 import { ConditionsFn, ErrorResponseFn, IConditionsParam, IDefaultInterceptor, IErrorMessage, IHttpErrorResponse, IHttpResponse, IInterceptorUtils, IPassThruBackend, IPostToOtherMethod, IRequestCore, IRequestInterceptor, ResponseFn } from '../interfaces/interceptor.interface';
@@ -84,7 +82,8 @@ export abstract class BackendService {
 
   private requestInterceptors: Array<IRequestInterceptor> = [];
 
-  protected dbReadySubject: BehaviorSubject<boolean>;
+  protected dbReadyFn: (value: boolean) => void;
+  protected dbReadyPromise: Promise<boolean>;
   private passThruBackend: IPassThruBackend;
   protected config: BackendConfigArgs = {};
 
@@ -101,17 +100,19 @@ export abstract class BackendService {
     const loc = this.getLocation('/');
     this.config.host = this.config.host ? this.config.host : loc.host;     // default to app web server host
     this.config.rootPath = this.config.rootPath ? this.config.rootPath : loc.path; // default to path when app is served (e.g.'/')
-    this.dbReadySubject = new BehaviorSubject(false);
-    const sub = this.dbReadySubject.subscribe(value => {
-      if (value) {
-        this.adjustJoinFields();
-        sub.unsubscribe();
-      }
-    });
+    this.dbReadyPromise = new Promise<boolean>((resolve) => this.dbReadyFn = resolve);
+    this.onDbReadyAjustJoinFields();
     if (typeof this.config.log === 'boolean') {
       LOG.level = this.config.log ? LoggerLevel.TRACE : LoggerLevel.ERROR;
     } else {
       LOG.level = this.config.log;
+    }
+  }
+
+  private async onDbReadyAjustJoinFields() {
+    const value = await this.dbReadyPromise;
+    if (value) {
+      this.adjustJoinFields();
     }
   }
 
@@ -436,10 +437,6 @@ export abstract class BackendService {
     });
   }
 
-  private dbReady(): Observable<boolean> {
-    return this.dbReadySubject.asObservable().pipe(first((r: boolean) => r));
-  }
-
   protected logRequest(request: IRequestCore<IExtendEntity>): void {
     LOG.info(request);
   }
@@ -460,22 +457,26 @@ export abstract class BackendService {
     return response;
   }
 
-  handleRequest(req: IRequestCore<IExtendEntity>): Observable<IHttpResponse<unknown>> {
-    //  handle the request when there is an in-memory database
-    return this.dbReady().pipe(
-      map(() => this.logRequest(req)),
-      concatMap(() => this.handleRequest_(req).pipe(
-        tap(res => this.logResponse(res)),
-        map(res => this.convertResponse(res)),
-        catchError(err => {
-          this.logResponse(err);
-          return throwError(err);
-        })
-      ))
-    );
+  handleRequest<T>(req: IRequestCore<unknown>): Promise<IHttpResponse<T>>;
+  async handleRequest(req: IRequestCore<IExtendEntity>): Promise<IHttpResponse<unknown>> {
+
+    await this.dbReadyPromise;
+    this.logRequest(req);
+    
+    let response: IHttpResponse<unknown>;
+    try {
+      response = await this.handleRequest_(req);
+      this.logResponse(response);
+      response = this.convertResponse(response);      
+    } catch (error) {
+      this.logResponse(error);
+      throw error;
+    }
+
+    return response;
   }
 
-  private handleRequest_(req: IRequestCore<IExtendEntity>): Observable<IHttpResponse<unknown>> {
+  private handleRequest_(req: IRequestCore<IExtendEntity>): Promise<IHttpResponse<unknown>> {
 
     const url = req.urlWithParams ? req.urlWithParams : req.url;
     let method = req.method || 'GET';
@@ -483,7 +484,7 @@ export abstract class BackendService {
     const intInfo: IInterceptorInfo = {};
 
     const parsed: IParsedRequestUrl = this.parseRequestUrl(method, url, intInfo);
-    let response$: Observable<IHttpResponse<unknown>>;
+    let response$: Promise<IHttpResponse<unknown>>;
 
     if (intInfo.interceptor && intInfo.interceptor.applyToPath === 'complete') {
       const intUtils = this.createInterceptorUtils(url, undefined, intInfo.interceptorIds, parsed.query, req.body);
@@ -499,7 +500,7 @@ export abstract class BackendService {
           detailedMessage: 'Implement a valid response or configure service to dispatch to real backend. (config.passThruUnknownUrl)'
         };
         LOG.error('Has one complete interceptor, but it does not has a valid response.', error);
-        return throwError(this.utils.createErrorResponseOptions(url, STATUS.NOT_IMPLEMENTED, error));
+        return Promise.reject(this.utils.createErrorResponseOptions(url, STATUS.NOT_IMPLEMENTED, error));
       }
     }
 
@@ -536,14 +537,14 @@ export abstract class BackendService {
       };
       const message = 'Has no collection in database, and not dispatch request to real backend server';
       LOG.error(message, error)
-      return throwError(this.utils.createErrorResponseOptions(url, STATUS.NOT_FOUND, error));
+      return Promise.reject(this.utils.createErrorResponseOptions(url, STATUS.NOT_FOUND, error));
     }
   }
 
   abstract hasCollection(collectionName: string): boolean;
 
-  private collectionHandler(reqInfo: IRequestInfo): Observable<IHttpResponse<unknown>> {
-    let response$: Observable<IHttpResponse<unknown>>;
+  private collectionHandler(reqInfo: IRequestInfo): Promise<IHttpResponse<unknown>> {
+    let response$: Promise<IHttpResponse<unknown>>;
     switch (reqInfo.method.toLocaleLowerCase()) {
       case 'get':
         response$ = this.get(reqInfo);
@@ -563,7 +564,7 @@ export abstract class BackendService {
           detailedMessage: 'Only methods GET, POST, PUT and DELETE are allowed'
         };
         LOG.error('Has received a method not allowed', error);
-        response$ = throwError(this.utils.createErrorResponseOptions(reqInfo.url, STATUS.METHOD_NOT_ALLOWED, error));
+        response$ = Promise.reject(this.utils.createErrorResponseOptions(reqInfo.url, STATUS.METHOD_NOT_ALLOWED, error));
         break;
       }
     }
@@ -571,7 +572,11 @@ export abstract class BackendService {
   }
 
   abstract getInstance$(collectionName: string, id: string | number): Promise<unknown>;
-  abstract getAllByFilter$(collectionName: string, conditions?: Array<IQueryFilter>): Observable<unknown[]>;
+  abstract getAllByFilter$(
+    collectionName: string, 
+    conditions?: Array<IQueryFilter>, 
+    asObservable?: boolean
+  ): Promise<unknown[]> | /** @deprecated */ Observable<unknown[]>;
 
   abstract get$(
     collectionName: string,
@@ -579,8 +584,9 @@ export abstract class BackendService {
     query: Map<string, string[]>,
     url: string,
     getJoinFields?: IJoinField[],
-    caseSensitiveSearch?: boolean
-  ): Observable<
+    caseSensitiveSearch?: boolean,
+    asObservable?: boolean
+  ): Promise<
     IHttpResponse<unknown> |
     IHttpResponse<{ data: unknown }> |
     IHttpResponse<unknown[]> |
@@ -590,8 +596,8 @@ export abstract class BackendService {
 
   private get(
     { collectionName, id, query, url, interceptor, interceptorIds }: IRequestInfo
-  ): Observable<IHttpResponse<unknown>> {
-    let response$: Observable<IHttpResponse<unknown>>;
+  ): Promise<IHttpResponse<unknown>> {
+    let response$: Promise<IHttpResponse<unknown>>;
 
     // Caso tenha um interceptador, retorna a resposta do mesmo
     if (interceptor) {
@@ -602,7 +608,7 @@ export abstract class BackendService {
       }
     }
 
-    response$ = this.get$(collectionName, id, query, url);
+    response$ = this.get$(collectionName, id, query, url, undefined, undefined, false);
     return this.addDelay(response$, this.config.delay);
   }
 
@@ -685,7 +691,7 @@ export abstract class BackendService {
             name: 'id',
             fn: this.createFilterArrayFn('id', ids, null)
           }];
-          const data = await this.getAllByFilter$(joinField.collectionSource, conditions).toPromise() as IExtendEntity[];
+          const data = await (this.getAllByFilter$(joinField.collectionSource, conditions, false) as unknown) as IExtendEntity[];
           // Reordena na mesma ordem existente dos ids de busca
           const dataAux = [];
           ids.forEach((id, index) => {
@@ -786,10 +792,10 @@ export abstract class BackendService {
     });
   }
 
-  abstract post$(collectionName: string, id: string, item: unknown, url: string): Observable<IHttpResponse<unknown>>;
+  abstract post$(collectionName: string, id: string, item: unknown, url: string, asObservable?: boolean): Promise<IHttpResponse<unknown>>;
 
-  private post({ collectionName, id, body, url, interceptor, interceptorIds }: IRequestInfo): Observable<IHttpResponse<unknown>> {
-    let response$: Observable<IHttpResponse<unknown>>;
+  private post({ collectionName, id, body, url, interceptor, interceptorIds }: IRequestInfo): Promise<IHttpResponse<unknown>> {
+    let response$: Promise<IHttpResponse<unknown>>;
 
     // Caso tenha um interceptador, retorna a resposta do mesmo
     if (interceptor) {
@@ -800,25 +806,29 @@ export abstract class BackendService {
       }
     }
 
-    response$ = this.post$(collectionName, id, body, url);
+    response$ = this.post$(collectionName, id, body, url, false);
     return this.addDelay(response$, this.config.delay);
   }
 
   protected applyTransformPost(body: unknown, transformfn: TransformPostFn): Promise<IExtendEntity> {
     return new Promise<IExtendEntity>((resolve, reject) => {
-      const retorno = transformfn.call(this, body, this) as (IExtendEntity | Observable<IExtendEntity>);
+      // FIXME - Remover retorno como Observable quando for removido RxJs
+      const retorno = transformfn.call(this, body, this) as (IExtendEntity | Promise<IExtendEntity> |
+         /** @depreacted */ Observable<IExtendEntity>);
       if (retorno instanceof Observable) {
         retorno.subscribe(item => resolve(item), error => reject(error));
+      } else if (retorno instanceof Promise) {
+        retorno.then(item => resolve(item)).catch(error => reject(error));
       } else {
         resolve(retorno);
       }
     });
   }
 
-  abstract put$(collectionName: string, id: string, item: unknown, url: string): Observable<IHttpResponse<unknown>>;
+  abstract put$(collectionName: string, id: string, item: unknown, url: string, asObservable?: boolean): Promise<IHttpResponse<unknown>>;
 
-  private put({ collectionName, id, body, url, interceptor, interceptorIds }: IRequestInfo): Observable<IHttpResponse<unknown>> {
-    let response$: Observable<IHttpResponse<unknown>>;
+  private put({ collectionName, id, body, url, interceptor, interceptorIds }: IRequestInfo): Promise<IHttpResponse<unknown>> {
+    let response$: Promise<IHttpResponse<unknown>>;
 
     // Caso tenha um interceptador, retorna a resposta do mesmo
     if (interceptor) {
@@ -829,25 +839,29 @@ export abstract class BackendService {
       }
     }
 
-    response$ = this.put$(collectionName, id, body, url);
+    response$ = this.put$(collectionName, id, body, url, false);
     return this.addDelay(response$, this.config.delay);
   }
 
   protected applyTransformPut(item: IExtendEntity, body: unknown, transformfn: TransformPutFn): Promise<IExtendEntity> {
     return new Promise<IExtendEntity>((resolve, reject) => {
-      const retorno = transformfn.call(this, item, body, this) as (IExtendEntity | Observable<IExtendEntity>);
+      // FIXME - Remover retorno como Observable quando for removido RxJs
+      const retorno = transformfn.call(this, item, body, this) as (IExtendEntity | Promise<IExtendEntity> |
+        /** @depreacted */ Observable<IExtendEntity>);
       if (retorno instanceof Observable) {
         retorno.subscribe(itemObs => resolve(itemObs), error => reject(error));
+      } else if (retorno instanceof Promise) {
+        retorno.then(item => resolve(item)).catch(error => reject(error));
       } else {
         resolve(retorno);
       }
     });
   }
 
-  abstract delete$(collectionName: string, id: string, url: string): Observable<IHttpResponse<null>>;
+  abstract delete$(collectionName: string, id: string, url: string, asObservable?: boolean): Promise<IHttpResponse<null>>;
 
-  private delete({ collectionName, id, url, interceptor, interceptorIds }: IRequestInfo): Observable<IHttpResponse<unknown>> {
-    let response$: Observable<IHttpResponse<unknown>>;
+  private delete({ collectionName, id, url, interceptor, interceptorIds }: IRequestInfo): Promise<IHttpResponse<unknown>> {
+    let response$: Promise<IHttpResponse<unknown>>;
 
     // Caso tenha um interceptador, retorna a resposta do mesmo
     if (interceptor) {
@@ -858,7 +872,7 @@ export abstract class BackendService {
       }
     }
 
-    response$ = this.delete$(collectionName, id, url);
+    response$ = this.delete$(collectionName, id, url, false);
     return this.addDelay(response$, this.config.delay);
   }
 
@@ -886,7 +900,7 @@ export abstract class BackendService {
     return this.config.dataEncapsulation ? { data } : data;
   }
 
-  private addDelay(response$: Observable<IHttpResponse<unknown>>, delay: number): Observable<IHttpResponse<unknown>> {
+  private addDelay(response$: Promise<IHttpResponse<unknown>>, delay: number): Promise<IHttpResponse<unknown>> {
     return delay === 0 ? response$ : delayResponse(response$, (Math.floor((Math.random() * delay) + 1)) || 500);
   }
 
@@ -1361,19 +1375,21 @@ export abstract class BackendService {
 
   private processInterceptResponse(
     interceptor: IRequestInterceptor, utils: IInterceptorUtils
-  ): Observable<IHttpResponse<unknown>> {
+  ): Promise<IHttpResponse<unknown>> {
     LOG.trace('Response will be processed by the interceptor.', '(Interceptor Utils)', utils);
     const response = this.interceptResponse(interceptor, utils);
-    if (response instanceof Observable) {
+    if (response instanceof Promise) {
       return response;
     }
+    if (response instanceof Observable) {
+      return firstValueFrom(response);
+    }
     if (response !== undefined) {
-      return new Observable(observer => {
+      return new Promise((resolve, reject) => {
         if ((response as IHttpErrorResponse).error) {
-          observer.error(response);
+          reject(response);
         } else {
-          observer.next(response);
-          observer.complete();
+          resolve(response);
         }
       });
     }
@@ -1382,7 +1398,8 @@ export abstract class BackendService {
   }
 
   private interceptResponse(interceptor: IRequestInterceptor, utils: IInterceptorUtils):
-    IHttpResponse<unknown> | IHttpErrorResponse | Observable<IHttpResponse<unknown>> | undefined {
+    IHttpResponse<unknown> | IHttpErrorResponse | Promise<IHttpResponse<unknown>> | 
+    /** @deprecated */ Observable<IHttpResponse<unknown>> | undefined {
     let response: IHttpResponse<unknown>;
     if (interceptor.response) {
       if (interceptor.response instanceof Function) {
@@ -1665,7 +1682,7 @@ export abstract class BackendService {
     };
   }
 
-  protected dispatchErrorToResponse(observer: Subscriber<unknown>, url: string, error: unknown): void {
+  protected dispatchErrorToResponse(reject: (error: IHttpErrorResponse) => void, url: string, error: unknown): void {
     let message: string;
     let detailedMessage: unknown;
     if (typeof error === 'string') {
@@ -1686,7 +1703,7 @@ export abstract class BackendService {
     if (detailedMessage) {
       errorMessage.detailedMessage = detailedMessage;
     }
-    observer.error(this.utils.createErrorResponseOptions(url, STATUS.INTERNAL_SERVER_ERROR, errorMessage));
+    reject(this.utils.createErrorResponseOptions(url, STATUS.INTERNAL_SERVER_ERROR, errorMessage));
   }
 
   protected orderItems(collectionName: string, items: IExtendEntity[], orders: IQueryOrder[]): IExtendEntity[] {

--- a/src/database/src/data-service/indexed-db.service.ts
+++ b/src/database/src/data-service/indexed-db.service.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-this-alias */
-import { cloneDeep } from 'lodash';
 import { Observable, from } from 'rxjs';
 import { v4 } from 'uuid';
 import { IBackendService, IJoinField, LoadFn } from '../interfaces/backend.interface';
@@ -8,6 +7,7 @@ import { IHttpResponse, IPassThruBackend } from '../interfaces/interceptor.inter
 import { IQueryCursor, IQueryFilter, IQueryParams, IQueryResult } from '../interfaces/query.interface';
 import { STATUS } from '../utils/http-status-codes';
 import { BackendService, IExtendEntity } from './backend.service';
+import deepClone from 'clonedeep';
 
 interface IEventTargetError extends EventTarget {
   error: unknown;
@@ -420,7 +420,7 @@ export class IndexedDbService extends BackendService implements IBackendService 
                 item.id = requestAdd.result as (string | number);
                 (async () => {
                   if (this.config.returnItemIn201) {
-                    item = await this.applyTransformersGetById(collectionName, cloneDeep(item));
+                    item = await this.applyTransformersGetById(collectionName, deepClone(item));
                     return self.utils.createResponseOptions(url, STATUS.CREATED, self.bodify(item));
                   } else {
                     const response = this.utils.createResponseOptions(url, STATUS.CREATED, { id: item.id });
@@ -473,7 +473,7 @@ export class IndexedDbService extends BackendService implements IBackendService 
                 if (this.config.put204) {
                   return this.utils.createResponseOptions(url, STATUS.NO_CONTENT);
                 } else {
-                  item = await this.applyTransformersGetById(collectionName, cloneDeep(item));
+                  item = await this.applyTransformersGetById(collectionName, deepClone(item));
                   return this.utils.createResponseOptions(url, STATUS.OK, this.bodify(item));
                 }
               })().then(response => {
@@ -564,7 +564,7 @@ export class IndexedDbService extends BackendService implements IBackendService 
                 if (this.config.put204) {
                   return this.utils.createResponseOptions(url, STATUS.NO_CONTENT);
                 } else {
-                  item = await this.applyTransformersGetById(collectionName, cloneDeep(item));
+                  item = await this.applyTransformersGetById(collectionName, deepClone(item));
                   return this.utils.createResponseOptions(url, STATUS.OK, this.bodify(item));
                 }
               })().then(response => {
@@ -607,7 +607,7 @@ export class IndexedDbService extends BackendService implements IBackendService 
                 item.id = requestAdd.result as (string | number);
                 (async () => {
                   if (this.config.returnItemIn201) {
-                    item = await this.applyTransformersGetById(collectionName, cloneDeep(item));
+                    item = await this.applyTransformersGetById(collectionName, deepClone(item));
                     return self.utils.createResponseOptions(url, STATUS.CREATED, self.bodify(item));
                   } else {
                     const response = this.utils.createResponseOptions(url, STATUS.CREATED, { id: item.id });
@@ -713,7 +713,7 @@ export class IndexedDbService extends BackendService implements IBackendService 
     }
   }
 
-  createPassThruBackend(): IPassThruBackend {
-    throw new Error('Method not implemented.');
+  createFetchBackend(): IPassThruBackend {
+    return super.createFetchBackend();
   }
 }

--- a/src/database/src/data-service/memory-db.service.ts
+++ b/src/database/src/data-service/memory-db.service.ts
@@ -1,4 +1,3 @@
-import { cloneDeep } from 'lodash';
 import { Observable, from } from 'rxjs';
 import { v4 } from 'uuid';
 import { IBackendService, IJoinField, LoadFn } from '../interfaces/backend.interface';
@@ -7,6 +6,7 @@ import { IHttpResponse, IPassThruBackend } from '../interfaces/interceptor.inter
 import { IQueryCursor, IQueryFilter, IQueryParams, IQueryResult } from '../interfaces/query.interface';
 import { STATUS } from '../utils/http-status-codes';
 import { BackendService, IExtendEntity } from './backend.service';
+import deepClone from 'clonedeep';
 
 export class MemoryDbService extends BackendService implements IBackendService {
 
@@ -86,7 +86,7 @@ export class MemoryDbService extends BackendService implements IBackendService {
       const objectStore = this.db.get(collectionName);
       if (id !== undefined && id !== null && id !== '') {
         id = this.config.strategyId === 'autoincrement' && typeof id !== 'number' ? parseInt(id, 10) : id;
-        resolve(cloneDeep(this.findById(objectStore, id)) as unknown as T);
+        resolve(deepClone(this.findById(objectStore, id)) as unknown as T);
       } else {
         reject('Não foi passado o id');
       }
@@ -107,7 +107,7 @@ export class MemoryDbService extends BackendService implements IBackendService {
         continue: (): void => null
       };
       while (cursor.index <= objectStore.length) {
-        cursor.value = (cursor.index < objectStore.length) ? cloneDeep(objectStore[cursor.index++]) : null;
+        cursor.value = (cursor.index < objectStore.length) ? deepClone(objectStore[cursor.index++]) : null;
         if (this.getAllItems((cursor.value ? cursor : null), queryResults, queryParams)) {
           resolve(queryResults.items);
           break;
@@ -181,7 +181,7 @@ export class MemoryDbService extends BackendService implements IBackendService {
         const findId = id ? this.config.strategyId === 'autoincrement' ? parseInt(id, 10) : id : undefined;
         let item = this.findById(objectStore, findId);
 
-        item = item ? cloneDeep(item) : item;
+        item = item ? deepClone(item) : item;
 
         (async (itemAsync: IExtendEntity) => {
           if (itemAsync) {
@@ -218,7 +218,7 @@ export class MemoryDbService extends BackendService implements IBackendService {
           items = this.orderItems(collectionName, items, queryParams.orders);
         }
         while (cursor.index <= items.length) {
-          cursor.value = (cursor.index < items.length) ? cloneDeep(items[cursor.index++]) : null;
+          cursor.value = (cursor.index < items.length) ? deepClone(items[cursor.index++]) : null;
           if (this.getAllItems((cursor.value ? cursor : null), queryResults, queriesParams.root)) {
             break;
           }
@@ -278,7 +278,7 @@ export class MemoryDbService extends BackendService implements IBackendService {
           objectStore.splice(this.sortedIndex(objectStore, item.id), 0, item);
 
           if (this.config.returnItemIn201) {
-            item = await this.applyTransformersGetById(collectionName, cloneDeep(item));
+            item = await this.applyTransformersGetById(collectionName, deepClone(item));
             return this.utils.createResponseOptions(url, STATUS.CREATED, this.bodify(item));
           } else {
             const response = this.utils.createResponseOptions(url, STATUS.CREATED, { id: item.id });
@@ -311,7 +311,7 @@ export class MemoryDbService extends BackendService implements IBackendService {
           if (this.config.put204) {
             return this.utils.createResponseOptions(url, STATUS.NO_CONTENT);
           } else {
-            item = await this.applyTransformersGetById(collectionName, cloneDeep(item));
+            item = await this.applyTransformersGetById(collectionName, deepClone(item));
             return this.utils.createResponseOptions(url, STATUS.OK, this.bodify(item));
           }
         })().then(response => {
@@ -371,7 +371,7 @@ export class MemoryDbService extends BackendService implements IBackendService {
           if (this.config.put204) {
             return this.utils.createResponseOptions(url, STATUS.NO_CONTENT);
           } else {
-            item = await this.applyTransformersGetById(collectionName, cloneDeep(item));
+            item = await this.applyTransformersGetById(collectionName, deepClone(item));
             return this.utils.createResponseOptions(url, STATUS.OK, this.bodify(item));
           }
         })().then(response => {
@@ -399,7 +399,7 @@ export class MemoryDbService extends BackendService implements IBackendService {
           objectStore.splice(this.sortedIndex(objectStore, item.id), 0, item);
 
           if (this.config.returnItemIn201) {
-            item = await this.applyTransformersGetById(collectionName, cloneDeep(item));
+            item = await this.applyTransformersGetById(collectionName, deepClone(item));
             return this.utils.createResponseOptions(url, STATUS.CREATED, this.bodify(item));
           } else {
             const response = this.utils.createResponseOptions(url, STATUS.CREATED, { id: item.id });
@@ -511,7 +511,7 @@ export class MemoryDbService extends BackendService implements IBackendService {
     return low;
   }
 
-  createPassThruBackend(): IPassThruBackend {
-    throw new Error('Method not implemented.');
+  createFetchBackend(): IPassThruBackend {
+    return super.createFetchBackend();
   }
 }

--- a/src/database/src/data-service/memory-db.service.ts
+++ b/src/database/src/data-service/memory-db.service.ts
@@ -1,6 +1,5 @@
-/* eslint-disable @typescript-eslint/no-unsafe-argument */
 import { cloneDeep } from 'lodash';
-import { Observable, throwError } from 'rxjs';
+import { Observable, from } from 'rxjs';
 import { v4 } from 'uuid';
 import { IBackendService, IJoinField, LoadFn } from '../interfaces/backend.interface';
 import { BackendConfigArgs } from '../interfaces/configuration.interface';
@@ -18,7 +17,6 @@ export class MemoryDbService extends BackendService implements IBackendService {
   }
 
   createDatabase(): Promise<boolean> {
-    this.dbReadySubject.next(false);
     return new Promise<boolean>((resolve) => {
       this.db = new Map<string, IExtendEntity[]>();
       resolve(true);
@@ -26,7 +24,6 @@ export class MemoryDbService extends BackendService implements IBackendService {
   }
 
   deleteDatabase(): Promise<boolean> {
-    this.dbReadySubject.next(false);
     return new Promise<boolean>((resolve) => {
       this.db = undefined;
       resolve(true);
@@ -49,7 +46,7 @@ export class MemoryDbService extends BackendService implements IBackendService {
       } else {
         console.warn('[WebBackendApi]', 'There is not collection in data service!');
       }
-      this.dbReadySubject.next(true);
+      this.dbReadyFn(true);
       resolve(true);
     });
   }
@@ -96,8 +93,10 @@ export class MemoryDbService extends BackendService implements IBackendService {
     });
   }
 
-  getAllByFilter$(collectionName: string, conditions?: IQueryFilter[]): Observable<unknown[]> {
-    return new Observable((observer) => {
+  getAllByFilter$(collectionName: string, conditions?: IQueryFilter[], asObservable?: boolean): Observable<unknown[]>;
+  getAllByFilter$(collectionName: string, conditions?: IQueryFilter[], asObservable?: boolean): Promise<unknown[]>;
+  getAllByFilter$(collectionName: string, conditions?: IQueryFilter[], asObservable = true): Promise<unknown[]> | Observable<unknown[]> {
+    const ret = new Promise<unknown[]>((resolve) => {
       const objectStore = this.db.get(collectionName);
       const queryParams: IQueryParams = { count: 0, conditions };
       const queryResults: IQueryResult<IExtendEntity> = { hasNext: false, items: [] };
@@ -110,12 +109,13 @@ export class MemoryDbService extends BackendService implements IBackendService {
       while (cursor.index <= objectStore.length) {
         cursor.value = (cursor.index < objectStore.length) ? cloneDeep(objectStore[cursor.index++]) : null;
         if (this.getAllItems((cursor.value ? cursor : null), queryResults, queryParams)) {
-          observer.next(queryResults.items);
-          observer.complete();
+          resolve(queryResults.items);
           break;
         }
       }
     });
+    // FIXME Remove this code when clear deprecated return
+    return asObservable ? from(ret) : ret;
   }
 
   count$(collectionName: string): Promise<number> {
@@ -129,15 +129,52 @@ export class MemoryDbService extends BackendService implements IBackendService {
     query: Map<string, string[]>,
     url: string,
     getJoinFields?: IJoinField[],
-    caseSensitiveSearch?: boolean
+    caseSensitiveSearch?: boolean,
+    asObservable?: boolean
   ): Observable<
     IHttpResponse<unknown> |
     IHttpResponse<{ data: unknown }> |
     IHttpResponse<unknown[]> |
     IHttpResponse<{ data: unknown[] }> |
     IHttpResponse<IQueryResult<unknown>>
+  >;
+  get$(
+    collectionName: string,
+    id: string,
+    query: Map<string, string[]>,
+    url: string,
+    getJoinFields?: IJoinField[],
+    caseSensitiveSearch?: boolean,
+    asObservable?: boolean
+  ): Promise<
+    IHttpResponse<unknown> |
+    IHttpResponse<{ data: unknown }> |
+    IHttpResponse<unknown[]> |
+    IHttpResponse<{ data: unknown[] }> |
+    IHttpResponse<IQueryResult<unknown>>
+  >;
+  get$(
+    collectionName: string,
+    id: string,
+    query: Map<string, string[]>,
+    url: string,
+    getJoinFields?: IJoinField[],
+    caseSensitiveSearch?: boolean,
+    asObservable = true
+  ): Promise<
+    IHttpResponse<unknown> |
+    IHttpResponse<{ data: unknown }> |
+    IHttpResponse<unknown[]> |
+    IHttpResponse<{ data: unknown[] }> |
+    IHttpResponse<IQueryResult<unknown>>
+  > | Observable<
+    IHttpResponse<unknown> |
+    IHttpResponse<{ data: unknown }> |
+    IHttpResponse<unknown[]> |
+    IHttpResponse<{ data: unknown[] }> |
+    IHttpResponse<IQueryResult<unknown>>
   > {
-    return new Observable((observer) => {
+    const ret = new Promise((resolve, reject) => {
       const objectStore = this.db.get(collectionName);
 
       if (id !== undefined && id !== '') {
@@ -155,15 +192,14 @@ export class MemoryDbService extends BackendService implements IBackendService {
           itemAsync => {
             if (itemAsync) {
               const response = this.utils.createResponseOptions(url, STATUS.OK, this.bodify(itemAsync));
-              observer.next(response as (IHttpResponse<unknown> | IHttpResponse<{ data: unknown }>));
-              observer.complete();
+              resolve(response as (IHttpResponse<unknown> | IHttpResponse<{ data: unknown }>));
             } else {
               // eslint-disable-next-line max-len
               const response = this.utils.createErrorResponseOptions(url, STATUS.NOT_FOUND, `Request id does not match item with id: ${id}`);
-              observer.error(response);
+              reject(response);
             }
           },
-          (error) => this.dispatchErrorToResponse(observer, url, error)
+          (error) => this.dispatchErrorToResponse(reject, url, error)
         );
       } else {
         let queryParams: IQueryParams = { count: 0 };
@@ -198,16 +234,20 @@ export class MemoryDbService extends BackendService implements IBackendService {
           () => {
             const response = this.utils.createResponseOptions(url, STATUS.OK, this.pagefy(queryResults, queryParams));
             // eslint-disable-next-line max-len
-            observer.next(response as (IHttpResponse<unknown[]> | IHttpResponse<{ data: unknown[] }> | IHttpResponse<IQueryResult<unknown>>));
-            observer.complete();
+            resolve(response as (IHttpResponse<unknown[]> | IHttpResponse<{ data: unknown[] }> | IHttpResponse<IQueryResult<unknown>>));
           },
-          (error) => this.dispatchErrorToResponse(observer, url, error));
+          (error) => this.dispatchErrorToResponse(reject, url, error));
       }
     });
+    // FIXME Remove this code when clear deprecated return
+    return asObservable ? from(ret) : ret;
   }
 
-  post$(collectionName: string, id: string, item: IExtendEntity, url: string): Observable<IHttpResponse<unknown>> {
-    return new Observable((observer) => {
+  post$(collectionName: string, id: string, item: unknown, url: string, asObservable?: boolean): Observable<IHttpResponse<unknown>>;
+  post$(collectionName: string, id: string, item: unknown, url: string, asObservable?: boolean): Promise<IHttpResponse<unknown>>;
+  post$(collectionName: string, id: string, item: IExtendEntity, url: string, asObservable = true):
+    Promise<IHttpResponse<unknown>> | Observable<IHttpResponse<unknown>> {
+    const ret = new Promise((resolve, reject) => {
       const objectStore = this.db.get(collectionName);
 
       let findId = id ? this.config.strategyId === 'autoincrement' ? parseInt(id, 10) : id : undefined;
@@ -220,7 +260,7 @@ export class MemoryDbService extends BackendService implements IBackendService {
       if (findId && item.id && findId !== item.id) {
         const error = `Request id (${findId}) does not match item.id (${item.id})`;
         const response = this.utils.createErrorResponseOptions(url, STATUS.BAD_REQUEST, error);
-        observer.error(response);
+        reject(response);
         return;
       } else {
         findId = item.id ? item.id : findId;
@@ -246,16 +286,15 @@ export class MemoryDbService extends BackendService implements IBackendService {
             return response;
           }
         })().then(response => {
-          observer.next(response);
-          observer.complete();
-        }, error => this.dispatchErrorToResponse(observer, url, error));
+          resolve(response);
+        }, error => this.dispatchErrorToResponse(reject, url, error));
       } else if (this.config.post409) {
         const error = {
           message: `'${collectionName}' item with id='${id}' exists and may not be updated with POST.`,
           detailedMessage: 'Use PUT instead.'
         };
         const response = this.utils.createErrorResponseOptions(url, STATUS.CONFLICT, error);
-        observer.error(response);
+        reject(response);
       } else {
         (async () => {
           const transformfn = this.transformPutMap.get(collectionName);
@@ -276,33 +315,39 @@ export class MemoryDbService extends BackendService implements IBackendService {
             return this.utils.createResponseOptions(url, STATUS.OK, this.bodify(item));
           }
         })().then(response => {
-          observer.next(response);
-          observer.complete();
-        }, error => this.dispatchErrorToResponse(observer, url, error));
+          resolve(response);
+        }, error => this.dispatchErrorToResponse(reject, url, error));
       }
     });
+    // FIXME Remove this code when clear deprecated return
+    return asObservable ? from(ret) : ret;
   }
 
-  put$(collectionName: string, id: string, item: IExtendEntity, url: string): Observable<IHttpResponse<unknown>> {
-    // eslint-disable-next-line eqeqeq
-    if (id == undefined) {
-      return throwError(this.utils.createErrorResponseOptions(url, STATUS.BAD_REQUEST, `Missing ${collectionName} id`));
-    }
+  put$(collectionName: string, id: string, item: unknown, url: string, asObservable?: boolean): Observable<IHttpResponse<unknown>>;
+  put$(collectionName: string, id: string, item: unknown, url: string, asObservable?: boolean): Promise<IHttpResponse<unknown>>;
+  put$(collectionName: string, id: string, item: IExtendEntity, url: string, asObservable = true):
+    Promise<IHttpResponse<unknown>> | Observable<IHttpResponse<unknown>> {
+    const ret = new Promise((resolve, reject) => {
+      // eslint-disable-next-line eqeqeq
+      if (id == undefined) {
+        reject(this.utils.createErrorResponseOptions(url, STATUS.BAD_REQUEST, `Missing ${collectionName} id`));
+        return;
+      }
 
-    if (item.id) {
-      item.id = this.config.strategyId === 'autoincrement' && typeof item.id !== 'number' ? parseInt(item.id, 10) : item.id;
-    }
+      if (item.id) {
+        item.id = this.config.strategyId === 'autoincrement' && typeof item.id !== 'number' ? parseInt(item.id, 10) : item.id;
+      }
 
-    const findId = this.config.strategyId === 'autoincrement' ? parseInt(id, 10) : id;
-    if (item.id && item.id !== findId) {
-      const error = {
-        message: `Request for ${collectionName} id (${id}) does not match item.id (${item.id})`,
-        detailedMessage: `Don't provide item.id in body or provide same id in both (url, body).`
-      };
-      return throwError(this.utils.createErrorResponseOptions(url, STATUS.BAD_REQUEST, error));
-    }
+      const findId = this.config.strategyId === 'autoincrement' ? parseInt(id, 10) : id;
+      if (item.id && item.id !== findId) {
+        const error = {
+          message: `Request for ${collectionName} id (${id}) does not match item.id (${item.id})`,
+          detailedMessage: `Don't provide item.id in body or provide same id in both (url, body).`
+        };
+        reject(this.utils.createErrorResponseOptions(url, STATUS.BAD_REQUEST, error));
+        return;
+      }
 
-    return new Observable((observer) => {
       const objectStore = this.db.get(collectionName);
       const existingIx = this.indexOf(objectStore, findId);
 
@@ -330,9 +375,8 @@ export class MemoryDbService extends BackendService implements IBackendService {
             return this.utils.createResponseOptions(url, STATUS.OK, this.bodify(item));
           }
         })().then(response => {
-          observer.next(response);
-          observer.complete();
-        }, error => this.dispatchErrorToResponse(observer, url, error));
+          resolve(response);
+        }, error => this.dispatchErrorToResponse(reject, url, error));
 
       } else if (this.config.put404) {
         const error = {
@@ -340,7 +384,7 @@ export class MemoryDbService extends BackendService implements IBackendService {
           detailedMessage: 'Use POST instead.'
         };
         const response = this.utils.createErrorResponseOptions(url, STATUS.NOT_FOUND, error);
-        observer.error(response);
+        reject(response);
       } else {
         if (!item.id) {
           item['id'] = findId;
@@ -363,31 +407,38 @@ export class MemoryDbService extends BackendService implements IBackendService {
             return response;
           }
         })().then(response => {
-          observer.next(response);
-          observer.complete();
-        }, error => this.dispatchErrorToResponse(observer, url, error));
+          resolve(response);
+        }, error => this.dispatchErrorToResponse(reject, url, error));
       }
     });
+    // FIXME Remove this code when clear deprecated return
+    return asObservable ? from(ret) : ret;
   }
 
-  delete$(collectionName: string, id: string, url: string): Observable<IHttpResponse<null>> {
-    // eslint-disable-next-line eqeqeq
-    if (id == undefined) {
-      return throwError(this.utils.createErrorResponseOptions(url, STATUS.BAD_REQUEST, `Missing ${collectionName} id`));
-    }
-    return new Observable((observer) => {
+  delete$(collectionName: string, id: string, url: string, asObservable?: boolean): Observable<IHttpResponse<null>>;
+  delete$(collectionName: string, id: string, url: string, asObservable?: boolean): Promise<IHttpResponse<null>>;
+  delete$(collectionName: string, id: string, url: string, asObservable = true):
+    Promise<IHttpResponse<null>> | Observable<IHttpResponse<null>> {
+    const ret = new Promise((resolve, reject) => {
+      // eslint-disable-next-line eqeqeq
+      if (id == undefined) {
+        reject(this.utils.createErrorResponseOptions(url, STATUS.BAD_REQUEST, `Missing ${collectionName} id`));
+        return;
+      }
+
       const objectStore = this.db.get(collectionName);
       const findId = this.config.strategyId === 'autoincrement' ? parseInt(id, 10) : id;
       if (this.removeById(objectStore, findId) || !this.config.delete404) {
         const response = this.utils.createResponseOptions(url, STATUS.NO_CONTENT);
-        observer.next(response as IHttpResponse<null>);
-        observer.complete();
+        resolve(response as IHttpResponse<null>);
       } else {
         const error = { message: `Error to find ${collectionName} with id (${id})`, detailedMessage: 'Id não encontrado.' };
         const response = this.utils.createErrorResponseOptions(url, STATUS.NOT_FOUND, error);
-        observer.error(response);
+        reject(response);
       }
     });
+    // FIXME Remove this code when clear deprecated return
+    return asObservable ? from(ret) : ret;
   }
 
   private generateStrategyId(collection: IExtendEntity[], collectionName: string, url?: string): string | number {

--- a/src/database/src/interfaces/backend.interface.ts
+++ b/src/database/src/interfaces/backend.interface.ts
@@ -15,16 +15,18 @@ export type LoadFn = (dbService: IBackendService) => void;
  * Este tipo será utilizado para fazer os mapeamentos nos endpoints de GetAll e GetById
  * @param item - Instância do item da coleção conforme está `persistido` no backend
  * @param dbService - Instância do serviço de backend
+ * @deprecated Depreciado o retorno como Observable
  */
-export type TransformGetFn = (item: unknown, dbService: IBackendService) => unknown | Observable<unknown>;
+export type TransformGetFn = (item: unknown, dbService: IBackendService) => unknown | Promise<unknown> | /** @deprecated */ Observable<unknown>;
 
 /**
  * Tipo para uma assinatura de função de callback a ser aplicada sobre um item a ser persistido no backend.
  * Este tipo será utilizado para fazer os mapeamentos nos endpoints de Post ou Put quando `config.put404 = false`
  * @param body - Conteúdo do corpo da requisição
  * @param dbService - Instância do serviço de backend
+ * @deprecated Depreciado o retorno como Observable
  */
-export type TransformPostFn = (body: unknown, dbService: IBackendService) => unknown | Observable<unknown>;
+export type TransformPostFn = (body: unknown, dbService: IBackendService) => unknown | Promise<unknown> | /** @deprecated */ Observable<unknown>;
 
 /**
  * Tipo para uma assinatura de função de callback a ser aplicada sobre um item a ser persistido no backend.
@@ -32,8 +34,9 @@ export type TransformPostFn = (body: unknown, dbService: IBackendService) => unk
  * @param item - Instância do item da coleção conforme está `persistido` no backend
  * @param body - Conteúdo do corpo da requisição
  * @param dbService - Instância do serviço de backend
+ * @deprecated Depreciado o retorno como Observable
  */
-export type TransformPutFn = (item: unknown, body: unknown, dbService: IBackendService) => unknown | Observable<unknown>;
+export type TransformPutFn = (item: unknown, body: unknown, dbService: IBackendService) => unknown | Promise<unknown> | /** @deprecated */ Observable<unknown>;
 
 /**
  * Interface que permite o mapeamento dos JOINs a serem feitos ao recuperar um item da coleção
@@ -92,21 +95,22 @@ export interface IBackendService {
   /**
    * Efetua o processamento da requisição HTTP
    * @param req Requisição HTTP a ser processada
-   * @returns Um observable com uma resposta HTTP indicando sucesso ou erro na operação.
+   * @returns Uma Promise com uma resposta HTTP indicando sucesso ou erro na operação.
    */
-  handleRequest(req: IRequestCore<unknown>): Observable<IHttpResponse<unknown>>;
+  handleRequest<T>(req: IRequestCore<unknown>): Promise<IHttpResponse<T>>;
+  handleRequest(req: IRequestCore<unknown>): Promise<IHttpResponse<unknown>>;
 
   /* set */ backendUtils(value: IBackendUtils): void;
 
   /**
    * Efetua a criação do banco de dados conforme a necessidade.
-   * @return Uma Promisse que devolve um boleano indicando sucesso ou fracasso da operação.
+   * @return Uma Promise que devolve um boleano indicando sucesso ou fracasso da operação.
    */
   createDatabase(): Promise<boolean>;
 
   /**
    * Efetua a exclusão do banco de dados conforme a necessidade.
-   * @return Uma Promisse que devolve um boleano indicando sucesso ou fracasso da operação.
+   * @return Uma Promise que devolve um boleano indicando sucesso ou fracasso da operação.
    */
   deleteDatabase(): Promise<boolean>;
 
@@ -114,6 +118,7 @@ export interface IBackendService {
    * Efetua a criação das colecões de itens utilizando como nomes as chaves do mapeamento.
    * Quando passado uma instancia de função válida no valor do mapeamento irá disparar
    * esta função para a coleção ao final do processo de criação de todas as coleções.
+   * @return Uma Promise que devolve um boleano indicando sucesso ou fracasso da operação.
    */
   createObjectStore(dataServiceFn: Map<string, LoadFn[]>): Promise<boolean>;
 
@@ -133,14 +138,14 @@ export interface IBackendService {
    * Grava um registro na coleção retornando o seu respectivo ID
    * @param collectionName - Nome da coleção a qual se deseja adicionar dados
    * @param data - Dado (objeto) que se deseja adicionar a coleção
-   * @return Uma Promisse que devolve o id da entidade armazenada.
+   * @return Uma Promise que devolve o id da entidade armazenada.
    */
   storeData(collectionName: string, data: unknown): Promise<string | number>;
 
   /**
    * Limpa todos os registro de uma determinada coleção
    * @param collectionName - Nome da coleção a qual se deseja limpar dados
-   * @return Uma Promisse que devolve um boleano indicando sucesso ou fracasso da operação.
+   * @return Uma Promise que devolve um boleano indicando sucesso ou fracasso da operação.
    */
   clearData(collectionName: string): Promise<boolean>;
 
@@ -412,9 +417,15 @@ export interface IBackendService {
    * o item não será submetido a função de transformação mapeada, caso esta exista.
    * @param collectionName - Nome da coleção a qual se deseja buscar o item
    * @param conditions - Lista de condições a serem aplicadas para filtar os itens
-   * @returns Um observable que retorna a listagem dos itens quando completo.
+   * @param asObservable - Compatibilidade, permite já expandir para retornar como Promise, caso seja passado `false`
+   * @returns Uma Promise ou observable (deprecated) que retorna a listagem dos itens quando completo.
+   * @deprecated Depreciado o método que retorna um Observable
+   * 
+   * Para compatibilidade será mantido nesta versão o retorno como Observable, porém, caso seja passado `false`
+   * no último parametro o retorno já será uma Promise
    */
-  getAllByFilter$(collectionName: string, conditions?: IQueryFilter[]): Observable<unknown[]>;
+  getAllByFilter$(collectionName: string, conditions?: IQueryFilter[], asObservable?: boolean): Observable<unknown[]>;
+  getAllByFilter$(collectionName: string, conditions?: IQueryFilter[], asObservable?: boolean): Promise<unknown[]>;
 
   /**
    * Permite retornar a quantidade de registros da coleção.
@@ -437,7 +448,11 @@ export interface IBackendService {
    * @param url URl a ser utilizada na resposta
    * @param getJoinFields Configuração de JOIN para ser utilizada ao recuperar os itens da coleção
    * @param caseSensitiveSearch Indica se a pesquisa deve ser case sensitive.
-   * @returns Um observable que retorna uma resposta HTTP contendo o item ou os itens no corpo da mesma
+   * @returns Uma Promise ou observable (deprecated) que retorna uma resposta HTTP contendo o item ou os itens no corpo da mesma
+   * @deprecated Depreciado o método que retorna um Observable
+   * 
+   * Para compatibilidade será mantido nesta versão o retorno como Observable, porém, caso seja passado `false`
+   * no último parametro o retorno já será uma Promise
    */
   get$(
     collectionName: string,
@@ -445,8 +460,24 @@ export interface IBackendService {
     query: Map<string, string[]>,
     url: string,
     getJoinFields?: IJoinField[],
-    caseSensitiveSearch?: boolean
+    caseSensitiveSearch?: boolean,
+    asObservable?: boolean
   ): Observable<
+    IHttpResponse<unknown> |
+    IHttpResponse<{ data: unknown }> |
+    IHttpResponse<unknown[]> |
+    IHttpResponse<{ data: unknown[] }> |
+    IHttpResponse<IQueryResult<unknown>>
+  >;
+  get$(
+    collectionName: string,
+    id: string,
+    query: Map<string, string[]>,
+    url: string,
+    getJoinFields?: IJoinField[],
+    caseSensitiveSearch?: boolean,
+    asObservable?: boolean
+  ): Promise<
     IHttpResponse<unknown> |
     IHttpResponse<{ data: unknown }> |
     IHttpResponse<unknown[]> |
@@ -464,10 +495,15 @@ export interface IBackendService {
    * @param id Identificador do item que se deseja criar (Opcional)
    * @param item Conteúdo do corpo da requisição HTTP
    * @param url URl a ser utilizada na resposta
-   * @returns Um observable que retorna uma resposta HTTP indicando sucesso ou erro na operação
+   * @returns Uma Promise ou um observable (deprecated) que retorna uma resposta HTTP indicando sucesso ou erro na operação
    * @alias BackendConfigArgs
+   * @deprecated Depreciado o método que retorna um Observable
+   * 
+   * Para compatibilidade será mantido nesta versão o retorno como Observable, porém, caso seja passado `false`
+   * no último parametro o retorno já será uma Promise
    */
-  post$(collectionName: string, id: string, item: unknown, url: string): Observable<IHttpResponse<unknown>>;
+  post$(collectionName: string, id: string, item: unknown, url: string, asObservable?: boolean): Observable<IHttpResponse<unknown>>;
+  post$(collectionName: string, id: string, item: unknown, url: string, asObservable?: boolean): Promise<IHttpResponse<unknown>>;
 
   /**
    * Permite atualizar ou criar um item na coleção
@@ -479,10 +515,15 @@ export interface IBackendService {
    * @param id Identificador do item que se deseja atualizar
    * @param item Conteúdo do corpo da requisição HTTP
    * @param url URl a ser utilizada na resposta
-   * @returns Um observable que retorna uma resposta HTTP indicando sucesso ou erro na operação
+   * @returns Uma Promise ou um observable (deprecated) que retorna uma resposta HTTP indicando sucesso ou erro na operação
    * @alias BackendConfigArgs
+   * @deprecated Depreciado o método que retorna um Observable
+   * 
+   * Para compatibilidade será mantido nesta versão o retorno como Observable, porém, caso seja passado `false`
+   * no último parametro o retorno já será uma Promise
    */
-  put$(collectionName: string, id: string, item: unknown, url: string): Observable<IHttpResponse<unknown>>;
+  put$(collectionName: string, id: string, item: unknown, url: string, asObservable?: boolean): Observable<IHttpResponse<unknown>>;
+  put$(collectionName: string, id: string, item: unknown, url: string, asObservable?: boolean): Promise<IHttpResponse<unknown>>;
 
   /**
    * Permite excluir um item de uma determinada coleção.
@@ -491,9 +532,14 @@ export interface IBackendService {
    * @param collectionName Nome da coleação a qual se deseja buscar o/os item/itens
    * @param id Identificador do item que se deseja excluir
    * @param url URl a ser utilizada na resposta
-   * @returns Um observable que retorna uma resposta HTTP indicando sucesso ou erro na operação
+   * @returns Uma Promise ou um observable (deprecated) que retorna uma resposta HTTP indicando sucesso ou erro na operação
+   * @deprecated Depreciado o método que retorna um Observable
+   * 
+   * Para compatibilidade será mantido nesta versão o retorno como Observable, porém, caso seja passado `false`
+   * no último parametro o retorno já será uma Promise
    */
-  delete$(collectionName: string, id: string, url: string): Observable<IHttpResponse<null>>;
+  delete$(collectionName: string, id: string, url: string, asObservable?: boolean): Observable<IHttpResponse<null>>;
+  delete$(collectionName: string, id: string, url: string, asObservable?: boolean): Promise<IHttpResponse<null>>;
 
 }
 

--- a/src/database/src/interfaces/backend.interface.ts
+++ b/src/database/src/interfaces/backend.interface.ts
@@ -97,6 +97,7 @@ export interface IBackendService {
    * @param req Requisição HTTP a ser processada
    * @returns Uma Promise com uma resposta HTTP indicando sucesso ou erro na operação.
    */
+  handleRequest<T>(req: IRequestCore<unknown>): Promise<T>;
   handleRequest<T>(req: IRequestCore<unknown>): Promise<IHttpResponse<T>>;
   handleRequest(req: IRequestCore<unknown>): Promise<IHttpResponse<unknown>>;
 

--- a/src/database/src/interfaces/backend.interface.ts
+++ b/src/database/src/interfaces/backend.interface.ts
@@ -425,7 +425,7 @@ export interface IBackendService {
    * Para compatibilidade será mantido nesta versão o retorno como Observable, porém, caso seja passado `false`
    * no último parametro o retorno já será uma Promise
    */
-  getAllByFilter$(collectionName: string, conditions?: IQueryFilter[], asObservable?: boolean): Observable<unknown[]>;
+  getAllByFilter$(collectionName: string, conditions?: IQueryFilter[]): Observable<unknown[]>;
   getAllByFilter$(collectionName: string, conditions?: IQueryFilter[], asObservable?: boolean): Promise<unknown[]>;
 
   /**
@@ -461,8 +461,7 @@ export interface IBackendService {
     query: Map<string, string[]>,
     url: string,
     getJoinFields?: IJoinField[],
-    caseSensitiveSearch?: boolean,
-    asObservable?: boolean
+    caseSensitiveSearch?: boolean
   ): Observable<
     IHttpResponse<unknown> |
     IHttpResponse<{ data: unknown }> |
@@ -503,7 +502,7 @@ export interface IBackendService {
    * Para compatibilidade será mantido nesta versão o retorno como Observable, porém, caso seja passado `false`
    * no último parametro o retorno já será uma Promise
    */
-  post$(collectionName: string, id: string, item: unknown, url: string, asObservable?: boolean): Observable<IHttpResponse<unknown>>;
+  post$(collectionName: string, id: string, item: unknown, url: string): Observable<IHttpResponse<unknown>>;
   post$(collectionName: string, id: string, item: unknown, url: string, asObservable?: boolean): Promise<IHttpResponse<unknown>>;
 
   /**
@@ -523,7 +522,7 @@ export interface IBackendService {
    * Para compatibilidade será mantido nesta versão o retorno como Observable, porém, caso seja passado `false`
    * no último parametro o retorno já será uma Promise
    */
-  put$(collectionName: string, id: string, item: unknown, url: string, asObservable?: boolean): Observable<IHttpResponse<unknown>>;
+  put$(collectionName: string, id: string, item: unknown, url: string): Observable<IHttpResponse<unknown>>;
   put$(collectionName: string, id: string, item: unknown, url: string, asObservable?: boolean): Promise<IHttpResponse<unknown>>;
 
   /**
@@ -539,8 +538,10 @@ export interface IBackendService {
    * Para compatibilidade será mantido nesta versão o retorno como Observable, porém, caso seja passado `false`
    * no último parametro o retorno já será uma Promise
    */
-  delete$(collectionName: string, id: string, url: string, asObservable?: boolean): Observable<IHttpResponse<null>>;
+  delete$(collectionName: string, id: string, url: string): Observable<IHttpResponse<null>>;
   delete$(collectionName: string, id: string, url: string, asObservable?: boolean): Promise<IHttpResponse<null>>;
+
+  createFetchBackend(): IPassThruBackend;
 
 }
 

--- a/src/database/src/interfaces/interceptor.interface.ts
+++ b/src/database/src/interfaces/interceptor.interface.ts
@@ -324,5 +324,5 @@ export interface IPassThruBackend {
    * Handle an HTTP request and return an Observable of HTTP response
    * Both the request type and the response type are determined by the supporting HTTP library.
    */
-  handle(req: IRequestCore<unknown>): Observable<IHttpResponse<unknown> | IHttpErrorResponse>;
+  handle(req: IRequestCore<unknown>): Promise<IHttpResponse<unknown> | IHttpErrorResponse>;
 }

--- a/src/database/src/interfaces/interceptor.interface.ts
+++ b/src/database/src/interfaces/interceptor.interface.ts
@@ -4,9 +4,9 @@ import { IQueryFilter, FilterFn, FilterOp } from './query.interface';
 export interface IHeadersCore {
   set(name: string, value: string | string[]): void | unknown;
   append(name: string, value: string | string[]): void | unknown;
-  keys(): string[] | Iterator<string>;
+  // keys(): string[] | Iterator<string>;
   get(name: string): string | string[] | null;
-  getAll?(name: string): string | string[] | null;
+  // getAll?(name: string): string | string[] | null;
 }
 
 export interface IRequestCore<T> {
@@ -100,45 +100,49 @@ export type ConditionsFn = (conditions: IConditionsParam) => IQueryFilter[];
  *   });
  */
 export type ResponseInterceptorFn = (utils: IInterceptorUtils) =>
-  IHttpResponse<unknown> | IHttpErrorResponse | Observable<IHttpResponse<unknown> | IHttpErrorResponse>;
+  IHttpResponse<unknown> | IHttpErrorResponse |
+  Promise<IHttpResponse<unknown> | IHttpErrorResponse> |
+  /** @deprecated */ Observable<IHttpResponse<unknown> | IHttpErrorResponse>;
 
- /**
-  * Type for a default response function that will be applied to a request interceptor.
-  * in all collections that has a match path with configuration.
-  * When returns a `Observable` the result of a observer must be a valid `HttpResponse`
-  * @example
-  * const config: BackendConfigArgs = {
-  *  . . . ,
-  *   defaultInterceptors: [
-  *     // add default interceptor to return then count for all collections
-  *     {
-  *       applyToPath: 'beforeId',
-  *       method: 'GET',
-  *       path: `count`,
-  *       responseFn: (colectionName: string, utils: IInterceptorUtils) =>
-  *         new Observable(observer => {
-  *           (async () => {
-  *             const dbService = getBackendService();
-  *             const count = await dbService.count$(colectionName);
-  *             observer.next(utils.fn.response(utils.url, 200, { count }));
-  *           })();
-  *         })
-  *     },
-  *     // add default interceptor for activate all collections
-  *     {
-  *        applyToPath: 'afterId',
-  *        method: 'PUT',
-  *        path: 'activate',
-  *        responseFn: (colectionName: string, utils: IInterceptorUtils) => {
-  *          const dbService = getBackendService();
-  *          return dbService.put$(colectionName, utils.id, { active: true }, utils.url);
-  *        }
-  *      }
-  *   ]
-  * }
-  */
+/**
+ * Type for a default response function that will be applied to a request interceptor.
+ * in all collections that has a match path with configuration.
+ * When returns a `Observable` the result of a observer must be a valid `HttpResponse`
+ * @example
+ * const config: BackendConfigArgs = {
+ *  . . . ,
+ *   defaultInterceptors: [
+ *     // add default interceptor to return then count for all collections
+ *     {
+ *       applyToPath: 'beforeId',
+ *       method: 'GET',
+ *       path: `count`,
+ *       responseFn: (colectionName: string, utils: IInterceptorUtils) =>
+ *         new Observable(observer => {
+ *           (async () => {
+ *             const dbService = getBackendService();
+ *             const count = await dbService.count$(colectionName);
+ *             observer.next(utils.fn.response(utils.url, 200, { count }));
+ *           })();
+ *         })
+ *     },
+ *     // add default interceptor for activate all collections
+ *     {
+ *        applyToPath: 'afterId',
+ *        method: 'PUT',
+ *        path: 'activate',
+ *        responseFn: (colectionName: string, utils: IInterceptorUtils) => {
+ *          const dbService = getBackendService();
+ *          return dbService.put$(colectionName, utils.id, { active: true }, utils.url);
+ *        }
+ *      }
+ *   ]
+ * }
+ */
 export type DefaultResponseInterceptorFn = (colectionName: string, utils: IInterceptorUtils) =>
-  IHttpResponse<unknown> | IHttpErrorResponse | Observable<IHttpResponse<unknown> | IHttpErrorResponse>;
+  IHttpResponse<unknown> | IHttpErrorResponse |
+  Promise<IHttpResponse<unknown> | IHttpErrorResponse> |
+  /** @deprecated */ Observable<IHttpResponse<unknown> | IHttpErrorResponse>;
 
 /**
  * Mapping interface for requests interceptions

--- a/src/database/src/utils/delay-response.ts
+++ b/src/database/src/utils/delay-response.ts
@@ -1,31 +1,9 @@
-import { Observable } from 'rxjs';
 
-// Replaces use of RxJS delay. See v0.5.4.
 /** adds specified delay (in ms) to both next and error channels of the response observable */
-export function delayResponse<T>(response$: Observable<T>, delayMs: number): Observable<T> {
-  return new Observable<T>(observer => {
-    let completePending = false;
-    let nextPending = false;
-    const subscription = response$.subscribe(
-      value => {
-        nextPending = true;
-        setTimeout(() => {
-          observer.next(value);
-          if (completePending) {
-            observer.complete();
-          }
-        }, delayMs);
-      },
-      error => setTimeout(() => observer.error(error), delayMs),
-      () => {
-        completePending = true;
-        if (!nextPending) {
-          observer.complete();
-        }
-      }
-    );
-    return () => {
-      return subscription.unsubscribe();
-    };
+export function delayResponse<T>(response$: Promise<T>, delayMs: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    response$
+      .then(value => setTimeout(() => resolve(value), delayMs))
+      .catch(reason => setTimeout(() => reject(reason), delayMs));
   });
 }

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-backend-api",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "private": false,
   "description": "API para simular um backend em memoria para ser usado em aplicações angular",
   "readmeFilename": "README.md",
@@ -24,12 +24,13 @@
   },
   "main": "public-api.ts",
   "peerDependencies": {
-    "@angular/common": "^15.2.0",
-    "@angular/core": "^15.2.0",
-    "rxjs": "^7.4.0",
+    "@angular/common": "13 - 17",
+    "@angular/core": "13 - 17",
+    "clonedeep": "^2.0.0",
+    "json.date-extensions": "^1.2.2",
     "json5": "^2.1.0",
-    "uuid": "^9.0.0",
-    "json.date-extensions": "^1.2.2"
+    "rxjs": "^7.4.0",
+    "uuid": "^9.0.0"
   },
   "dependencies": {
     "tslib": "^2.0.0"

--- a/src/test/join-fields/join-fields-collection.spec.ts
+++ b/src/test/join-fields/join-fields-collection.spec.ts
@@ -1,24 +1,24 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 import { TestCase } from 'jasmine-data-provider-ts';
 import { BackendConfig } from '../../database/src/data-service/backend-config';
-import { clone } from '../../database/src/data-service/backend.service';
 import { BackendTypeArgs, IBackendService, IHttpResponse, IndexedDbService, LoadFn, MemoryDbService } from '../../public-api';
 import { configureBackendUtils } from '../utils/configure-backend-utils';
 import { ICustomer, IOutboundDocument, IOutboundLoad, IProduct, collectionCustomers, collectionDocuments, collectionLoads, collectionProducts, customers, documents, loads, products } from './join-fields.mock';
+import deepClone from 'clonedeep';
 
 const dataServiceFn = new Map<string, LoadFn[]>();
 
 dataServiceFn.set(collectionLoads, [(dbService: IBackendService) => {
 
   loads.forEach(load => {
-    void dbService.storeData(collectionLoads, clone(load)).then(() => null);
+    void dbService.storeData(collectionLoads, deepClone(load)).then(() => null);
   });
 }]);
 
 dataServiceFn.set(collectionDocuments, [(dbService: IBackendService) => {
 
   documents.forEach(document => {
-    void dbService.storeData(collectionDocuments, clone(document)).then(() => null);
+    void dbService.storeData(collectionDocuments, deepClone(document)).then(() => null);
   })
 }]);
 
@@ -78,7 +78,7 @@ describe('Testes para JOIN de várias coleções com a configuração através d
       // given
       const expectedDocument = Object.assign(
         {},
-        clone(documents[0]),
+        deepClone(documents[0]),
         { customer: customers.find(item => item.id === documents[0].customerId) }
       );
       expectedDocument.items = expectedDocument.items.map(item => Object.assign(
@@ -110,7 +110,7 @@ describe('Testes para JOIN de várias coleções com a configuração através d
       // given
       const expectedDocuments = documents.map(document => Object.assign(
         {},
-        clone(document),
+        deepClone(document),
         { customer: customers.find(item => item.id === document.customerId) }
       ));
       expectedDocuments.forEach(document => {
@@ -147,7 +147,7 @@ describe('Testes para JOIN de várias coleções com a configuração através d
       // given
       const expectedDocument = Object.assign(
         {},
-        clone(documents[0]),
+        deepClone(documents[0]),
         { documentCustomer: customers.find(item => item.id === documents[0].customerId) }
       );
       delete expectedDocument.customerId;
@@ -189,7 +189,7 @@ describe('Testes para JOIN de várias coleções com a configuração através d
       const mapCustomer = ({ id, name }: ICustomer) => ({ id, name });
       const expectedDocument = Object.assign(
         {},
-        clone(documents[0]),
+        deepClone(documents[0]),
         { customer: mapCustomer(customers.find(item => item.id === documents[0].customerId)) }
       );
       delete expectedDocument.customerId;
@@ -234,7 +234,7 @@ describe('Testes para JOIN de várias coleções com a configuração através d
         const customer = customers.find(item => item.id === document.customerId);
         const result = Object.assign(
           {},
-          clone(document),
+          deepClone(document),
           { customerName: customer.name }
         );
         result.items = result.items.map(item => {
@@ -281,8 +281,8 @@ describe('Testes para JOIN de várias coleções com a configuração através d
 
     it(`Deve fazer a junção em uma colection de array de ids. DbType: ${dbType.dbtype}`, (done: DoneFn) => {
       // given
-      const expectedLoad = clone(loads[0]);
-      expectedLoad.documents = expectedLoad.documentsId.map(id => clone(documents.find(doc => doc.id === id)));
+      const expectedLoad = deepClone(loads[0]);
+      expectedLoad.documents = expectedLoad.documentsId.map(id => deepClone(documents.find(doc => doc.id === id)));
       // expectedLoad.createdAt = new Date(expectedLoad.createdAt);
       delete expectedLoad.documentsId;
       // To test addJoinGetAllMap by both method
@@ -309,9 +309,9 @@ describe('Testes para JOIN de várias coleções com a configuração através d
       // given
       const mapCustomer = ({ id, name }: ICustomer) => ({ id, name });
       const mapProduct = ({ id, code, description }: IProduct) => ({ id, code, description });
-      const expectedLoad = clone(loads[0]);
+      const expectedLoad = deepClone(loads[0]);
       expectedLoad.documents = expectedLoad.documentsId.map(id => {
-        let document = clone(documents.find(doc => doc.id === id));
+        let document = deepClone(documents.find(doc => doc.id === id));
         document = Object.assign(
           {},
           document,
@@ -361,10 +361,10 @@ describe('Testes para JOIN de várias coleções com a configuração através d
       // given
       const mapCustomer = ({ id, name }: ICustomer) => ({ id, name });
       const mapProduct = ({ id, code, description }: IProduct) => ({ id, code, description });
-      const expectedLoads = clone(loads);
+      const expectedLoads = deepClone(loads);
       expectedLoads.forEach(load => {
         load.documents = load.documentsId.map(id => {
-          let document = clone(documents.find(doc => doc.id === id));
+          let document = deepClone(documents.find(doc => doc.id === id));
           document = Object.assign(
             {},
             document,

--- a/src/test/join-fields/join-fields-get.spec.ts
+++ b/src/test/join-fields/join-fields-get.spec.ts
@@ -2,23 +2,23 @@
 import { TestCase } from 'jasmine-data-provider-ts';
 import { BackendTypeArgs, IBackendService, IHttpResponse, IJoinField, IndexedDbService, LoadFn, MemoryDbService } from '../../database/public-api';
 import { BackendConfig } from '../../database/src/data-service/backend-config';
-import { clone } from '../../database/src/data-service/backend.service';
 import { configureBackendUtils } from '../utils/configure-backend-utils';
 import { ICustomer, IOutboundDocument, IOutboundLoad, IProduct, collectionCustomers, collectionDocuments, collectionLoads, collectionProducts, customers, documents, loads, products } from './join-fields.mock';
+import deepClone from 'clonedeep';
 
 const dataServiceFn = new Map<string, LoadFn[]>();
 
 dataServiceFn.set(collectionLoads, [(dbService: IBackendService) => {
 
   loads.forEach(load => {
-    void dbService.storeData(collectionLoads, clone(load)).then(() => null);
+    void dbService.storeData(collectionLoads, deepClone(load)).then(() => null);
   });
 }]);
 
 dataServiceFn.set(collectionDocuments, [(dbService: IBackendService) => {
 
   documents.forEach(document => {
-    void dbService.storeData(collectionDocuments, clone(document)).then(() => null);
+    void dbService.storeData(collectionDocuments, deepClone(document)).then(() => null);
   })
 }]);
 
@@ -68,7 +68,7 @@ describe('Testes para JOIN de várias coleções com aplicação customizada par
       // given
       const expectedDocument = Object.assign(
         {},
-        clone(documents[0]),
+        deepClone(documents[0]),
         { customer: customers.find(item => item.id === documents[0].customerId) }
       );
       expectedDocument.items = expectedDocument.items.map(item => Object.assign(
@@ -99,7 +99,7 @@ describe('Testes para JOIN de várias coleções com aplicação customizada par
       // given
       const expectedDocuments = documents.map(document => Object.assign(
         {},
-        clone(document),
+        deepClone(document),
         { customer: customers.find(item => item.id === document.customerId) }
       ));
       expectedDocuments.forEach(document => {
@@ -135,7 +135,7 @@ describe('Testes para JOIN de várias coleções com aplicação customizada par
       // given
       const expectedDocument = Object.assign(
         {},
-        clone(documents[0]),
+        deepClone(documents[0]),
         { documentCustomer: customers.find(item => item.id === documents[0].customerId) }
       );
       delete expectedDocument.customerId;
@@ -176,7 +176,7 @@ describe('Testes para JOIN de várias coleções com aplicação customizada par
       const mapCustomer = ({ id, name }: ICustomer) => ({ id, name });
       const expectedDocument = Object.assign(
         {},
-        clone(documents[0]),
+        deepClone(documents[0]),
         { customer: mapCustomer(customers.find(item => item.id === documents[0].customerId)) }
       );
       delete expectedDocument.customerId;
@@ -217,7 +217,7 @@ describe('Testes para JOIN de várias coleções com aplicação customizada par
       // given
       const mapCustomer = ({ id, name }: ICustomer) => ({ id, name });
       const mapProduct = ({ id, code, description }: IProduct) => ({ id, code, description });
-      const expectedDocuments = clone(documents).map(document => {
+      const expectedDocuments = deepClone(documents).map(document => {
         document = Object.assign(
           {},
           document,
@@ -263,9 +263,9 @@ describe('Testes para JOIN de várias coleções com aplicação customizada par
 
     it(`Deve aplicar o sub-join pré configurado na collection. DbType: ${dbType.dbtype}`, (done: DoneFn) => {
       // given
-      const expectedLoad = clone(loads[0]);
+      const expectedLoad = deepClone(loads[0]);
       expectedLoad.documents = expectedLoad.documentsId.map(id => {
-        let document = clone(documents.find(doc => doc.id === id));
+        let document = deepClone(documents.find(doc => doc.id === id));
         document = Object.assign(
           {},
           document,

--- a/src/test/join-fields/join-fields-get.spec.ts
+++ b/src/test/join-fields/join-fields-get.spec.ts
@@ -41,20 +41,15 @@ describe('Testes para JOIN de várias coleções com aplicação customizada par
   TestCase<BackendTypeArgs>([{ dbtype: 'memory' }, { dbtype: 'indexdb' }], (dbType) => {
     let dbService: MemoryDbService | IndexedDbService;
 
-    beforeAll((done: DoneFn) => {
+    beforeAll(async () => {
       if (dbType.dbtype === 'memory') {
         dbService = new MemoryDbService(new BackendConfig({ pageEncapsulation: false, strategyId: 'uuid' }));
       } else {
         dbService = new IndexedDbService(new BackendConfig({ pageEncapsulation: false, strategyId: 'uuid' }));
       }
       configureBackendUtils(dbService);
-      dbService.createDatabase().then(
-        () => dbService.createObjectStore(dataServiceFn).then(
-          () => done(),
-          error => done.fail(error)
-        ),
-        error => done.fail(error)
-      );
+      await dbService.createDatabase();
+      await dbService.createObjectStore(dataServiceFn);
     });
 
     beforeEach(() => {
@@ -62,14 +57,11 @@ describe('Testes para JOIN de várias coleções com aplicação customizada par
       dbService.clearFieldFilterMap(collectionDocuments);
     });
 
-    afterAll((done: DoneFn) => {
+    afterAll(async () => {
       if (dbService instanceof IndexedDbService) {
         dbService.closeDatabase();
       }
-      dbService.deleteDatabase().then(
-        () => done(),
-        (error) => done.fail(error)
-      );
+      await dbService.deleteDatabase();
     });
 
     it(`Deve buscar um documento pelo id fazendo a junção dos campos. DbType: ${dbType.dbtype}`, (done: DoneFn) => {

--- a/src/test/simple-crud/extend-crud.spec.ts
+++ b/src/test/simple-crud/extend-crud.spec.ts
@@ -76,32 +76,22 @@ describe('Testes para uma aplicação CRUD com extensões', () => {
 
     }]);
 
-    beforeAll((done: DoneFn) => {
+    beforeAll(async () => {
       dbService = new MemoryDbService(backendConfig);
       configureBackendUtils(dbService);
-      dbService.createDatabase().then(
-        () => dbService.createObjectStore(dataServiceFn).then(
-          () => done(),
-          error => done.fail(error)
-        ),
-        error => done.fail(error)
-      );
+      await dbService.createDatabase();
+      await dbService.createObjectStore(dataServiceFn);
     });
 
-    afterAll((done: DoneFn) => {
-      dbService.deleteDatabase().then(
-        () => done(),
-        (error) => done.fail(error)
-      );
+    afterAll(async () => {
+      await dbService.deleteDatabase();
     })
 
-    beforeEach((done: DoneFn) => {
-      void (async (): Promise<void> => {
-        await dbService.clearData(collectionCustomers);
-        for (const customer of customers) {
-          await dbService.storeData(collectionCustomers, cloneDeep(customer));
-        }
-      })().then(() => done());
+    beforeEach(async () => {
+      await dbService.clearData(collectionCustomers);
+      for (const customer of customers) {
+        await dbService.storeData(collectionCustomers, cloneDeep(customer));
+      }
     })
 
     it(`Deve chamar o método PUT mesmo passando uma requisição de POST por Segmento URL.`, (done: DoneFn) => {
@@ -118,7 +108,7 @@ describe('Testes para uma aplicação CRUD com extensões', () => {
 
       const spyPut$ = spyOn(dbService, 'put$').and.callThrough();
       // when
-      dbService.handleRequest(req).subscribe(
+      dbService.handleRequest(req).then(
         (response: IHttpResponse<ICustomer>) => {
           // then
           expect(spyPut$).toHaveBeenCalled();
@@ -142,7 +132,7 @@ describe('Testes para uma aplicação CRUD com extensões', () => {
       };
       const spyPut$ = spyOn(dbService, 'put$').and.callThrough();
       // when
-      dbService.handleRequest(req).subscribe(
+      dbService.handleRequest(req).then(
         (response: IHttpResponse<ICustomer>) => {
           // then
           expect(spyPut$).toHaveBeenCalled();
@@ -167,7 +157,7 @@ describe('Testes para uma aplicação CRUD com extensões', () => {
       };
       const spyPut$ = spyOn(dbService, 'put$').and.callThrough();
       // when
-      dbService.handleRequest(req).subscribe(
+      dbService.handleRequest(req).then(
         (response: IHttpResponse<ICustomer>) => {
           // then
           expect(spyPut$).toHaveBeenCalled();
@@ -187,7 +177,7 @@ describe('Testes para uma aplicação CRUD com extensões', () => {
       };
       const spyDelete$ = spyOn(dbService, 'delete$').and.callThrough();
       // when
-      dbService.handleRequest(req).subscribe(
+      dbService.handleRequest(req).then(
         (response: IHttpResponse<null>) => {
           // then
           expect(spyDelete$).toHaveBeenCalled();
@@ -206,7 +196,7 @@ describe('Testes para uma aplicação CRUD com extensões', () => {
       };
       const spyDelete$ = spyOn(dbService, 'delete$').and.callThrough();
       // when
-      dbService.handleRequest(req).subscribe(
+      dbService.handleRequest(req).then(
         (response: IHttpResponse<null>) => {
           // then
           expect(spyDelete$).toHaveBeenCalled();
@@ -228,7 +218,7 @@ describe('Testes para uma aplicação CRUD com extensões', () => {
       };
       const spyDelete$ = spyOn(dbService, 'delete$').and.callThrough();
       // when
-      dbService.handleRequest(req).subscribe(
+      dbService.handleRequest(req).then(
         (response: IHttpResponse<null>) => {
           // then
           expect(spyDelete$).toHaveBeenCalled();

--- a/src/test/simple-crud/post-put-no-return-body.spec.ts
+++ b/src/test/simple-crud/post-put-no-return-body.spec.ts
@@ -36,30 +36,22 @@ describe('Testes de uma aplicação CRUD com comandos POST e PUT sem retorno de 
       delay: 0
     })
 
-    beforeAll((done: DoneFn) => {
+    beforeAll(async () => {
       if (dbType.dbtype === 'memory') {
         dbService = new MemoryDbService(backendConfig);
       } else {
         dbService = new IndexedDbService(backendConfig);
       }
       configureBackendUtils(dbService);
-      dbService.createDatabase().then(
-        () => dbService.createObjectStore(dataServiceFn).then(
-          () => done(),
-          error => done.fail(error)
-        ),
-        error => done.fail(error)
-      );
+      await dbService.createDatabase()
+      await dbService.createObjectStore(dataServiceFn);
     });
 
-    afterAll((done: DoneFn) => {
+    afterAll(async () => {
       if (dbService instanceof IndexedDbService) {
         dbService.closeDatabase();
       }
-      dbService.deleteDatabase().then(
-        () => done(),
-        (error) => done.fail(error)
-      );
+      await dbService.deleteDatabase();
     })
 
     it(`Deve retornar o location com o ID ao ser CREATED com POST e sem body. DbType: ${dbType.dbtype}`, (done: DoneFn) => {
@@ -72,14 +64,14 @@ describe('Testes de uma aplicação CRUD com comandos POST e PUT sem retorno de 
         }
       };
       // when
-      dbService.handleRequest(req).subscribe({
-        next: (response: (IHttpResponse<void> & { location: string })) => {
+      dbService.handleRequest(req).then(
+        (response: (IHttpResponse<void> & { location: string })) => {
           expect(response.status).toEqual(STATUS.CREATED);
           expect(response.body).toBeUndefined();
           expect(response.location).toContain('Location ID:');
           done();
         }
-      });
+      );
     });
 
     it(`Deve retornar o location com o ID ao ser CREATED com PUT e sem body. DbType: ${dbType.dbtype}`, (done: DoneFn) => {
@@ -93,18 +85,18 @@ describe('Testes de uma aplicação CRUD com comandos POST e PUT sem retorno de 
         }
       };
       // when
-      dbService.handleRequest(req).subscribe({
-        next: (response: (IHttpResponse<void> & { location: string })) => {
+      dbService.handleRequest(req).then(
+        (response: (IHttpResponse<void> & { location: string })) => {
           expect(response.status).toEqual(STATUS.CREATED);
           expect(response.body).toBeUndefined();
           expect(response.location).toEqual(`Location ID: ${id}`);
           done();
         },
-        error: (erro) => {
+        (erro) => {
           console.log("ERRO NO PUT CREATED", erro);
           done.fail(erro);
         }
-      });
+      );
     });
 
     it(`Deve retornar NO_CONTENT ao atualizar com POST e sem body. DbType: ${dbType.dbtype}`, (done: DoneFn) => {
@@ -117,13 +109,13 @@ describe('Testes de uma aplicação CRUD com comandos POST e PUT sem retorno de 
         }
       };
       // when
-      dbService.handleRequest(req).subscribe({
-        next: (response: IHttpResponse<void>) => {
+      dbService.handleRequest(req).then(
+        (response: IHttpResponse<void>) => {
           expect(response.status).toEqual(STATUS.NO_CONTENT);
           expect(response.body).toBeUndefined();
           done();
         }
-      });
+      );
     });
 
     it(`Deve retornar NO_CONTENT ao atualizar com PUT e sem body. DbType: ${dbType.dbtype}`, (done: DoneFn) => {
@@ -136,13 +128,13 @@ describe('Testes de uma aplicação CRUD com comandos POST e PUT sem retorno de 
         }
       };
       // when
-      dbService.handleRequest(req).subscribe({
-        next: (response: IHttpResponse<void>) => {
+      dbService.handleRequest(req).then(
+        (response: IHttpResponse<void>) => {
           expect(response.status).toEqual(STATUS.NO_CONTENT);
           expect(response.body).toBeUndefined();
           done();
         }
-      });
+      );
     });
 
   });

--- a/src/test/simple-crud/post-x-put-crud.spec.ts
+++ b/src/test/simple-crud/post-x-put-crud.spec.ts
@@ -92,7 +92,7 @@ describe('Testes para uma aplicação CRUD com POST como PUT e PUT como POST', (
       };
       const spyPut$ = spyOn(TransformersFn, 'transformePut').and.callThrough();
       // when
-      dbService.handleRequest(req).subscribe(
+      dbService.handleRequest(req).then(
         (response: IHttpResponse<ICustomer>) => {
           // then
           expect(spyPut$).toHaveBeenCalled();
@@ -117,7 +117,7 @@ describe('Testes para uma aplicação CRUD com POST como PUT e PUT como POST', (
       };
       const spyPost$ = spyOn(TransformersFn, 'transformePost').and.callThrough();
       // when
-      dbService.handleRequest(req).subscribe(
+      dbService.handleRequest(req).then(
         (response: IHttpResponse<ICustomer>) => {
           // then
           expect(spyPost$).toHaveBeenCalled();

--- a/src/test/simple-crud/simple-crud-fail.spec.ts
+++ b/src/test/simple-crud/simple-crud-fail.spec.ts
@@ -26,30 +26,22 @@ describe('Testes de falha de uma aplicação CRUD simples', () => {
       delay: 0
     })
 
-    beforeAll((done: DoneFn) => {
+    beforeAll(async () => {
       if (dbType.dbtype === 'memory') {
         dbService = new MemoryDbService(backendConfig);
       } else {
         dbService = new IndexedDbService(backendConfig);
       }
       configureBackendUtils(dbService);
-      dbService.createDatabase().then(
-        () => dbService.createObjectStore(dataServiceFn).then(
-          () => done(),
-          error => done.fail(error)
-        ),
-        error => done.fail(error)
-      );
+      await dbService.createDatabase();
+      await dbService.createObjectStore(dataServiceFn);
     });
 
-    afterAll((done: DoneFn) => {
+    afterAll(async () => {
       if (dbService instanceof IndexedDbService) {
         dbService.closeDatabase();
       }
-      dbService.deleteDatabase().then(
-        () => done(),
-        (error) => done.fail(error)
-      );
+      await dbService.deleteDatabase();
     })
 
     it(`Deve retornar NOT_FOUND ao fazer a busca por um id inexistente. DbType: ${dbType.dbtype}`, (done: DoneFn) => {
@@ -59,15 +51,15 @@ describe('Testes de falha de uma aplicação CRUD simples', () => {
         url: `http://localhost/${collectionCustomers}/99`,
       };
       // when
-      dbService.handleRequest(req).subscribe({
-        next: () => done.fail('Do not have return in Observable.next in this request'),
-        error: (erro: IHttpErrorResponse) => {
+      dbService.handleRequest(req).then(
+        () => done.fail('Do not have return in Observable.next in this request'),
+        (erro: IHttpErrorResponse) => {
           // then
           expect(erro.status).toEqual(STATUS.NOT_FOUND);
           expect(erro.error).toEqual(`Request id does not match item with id: ${99}`);
           done();
         }
-      });
+      );
     });
 
     it(`Deve retornar BAD_REQUEST ao tentar fazer POST com ID diferente do body. DbType: ${dbType.dbtype}`, (done: DoneFn) => {
@@ -81,15 +73,15 @@ describe('Testes de falha de uma aplicação CRUD simples', () => {
         }
       };
       // when
-      dbService.handleRequest(req).subscribe({
-        next: () => done.fail('Do not have return in Observable.next in this request'),
-        error: (erro: IHttpErrorResponse) => {
+      dbService.handleRequest(req).then(
+        () => done.fail('Do not have return in Observable.next in this request'),
+        (erro: IHttpErrorResponse) => {
           // then
           expect(erro.status).toEqual(STATUS.BAD_REQUEST);
           expect(erro.error).toEqual(`Request id (${98}) does not match item.id (${99})`);
           done();
         }
-      });
+      );
     });
 
     it(`Deve retornar CONFLICT ao tentar fazer POST para atualizar item existente. DbType: ${dbType.dbtype}`, (done: DoneFn) => {
@@ -106,15 +98,15 @@ describe('Testes de falha de uma aplicação CRUD simples', () => {
         detailedMessage: 'Use PUT instead.'
       };
       // when
-      dbService.handleRequest(req).subscribe({
-        next: () => done.fail('Do not have return in Observable.next in this request'),
-        error: (erro: IHttpErrorResponse) => {
+      dbService.handleRequest(req).then(
+        () => done.fail('Do not have return in Observable.next in this request'),
+        (erro: IHttpErrorResponse) => {
           // then
           expect(erro.status).toEqual(STATUS.CONFLICT);
           expect(erro.error).toEqual(responseError);
           done();
         }
-      });
+      );
     });
 
     it(`Deve retornar BAD_REQUEST ao tentar fazer PUT sem informar o ID. DbType: ${dbType.dbtype}`, (done: DoneFn) => {
@@ -127,14 +119,14 @@ describe('Testes de falha de uma aplicação CRUD simples', () => {
         }
       };
       // when
-      dbService.handleRequest(req).subscribe({
-        next: () => done.fail('Do not have return in Observable.next in this request'),
-        error: (erro: IHttpErrorResponse) => {
+      dbService.handleRequest(req).then(
+        () => done.fail('Do not have return in Observable.next in this request'),
+        (erro: IHttpErrorResponse) => {
           expect(erro.status).toEqual(STATUS.BAD_REQUEST);
           expect(erro.error).toEqual(`Missing ${collectionCustomers} id`);
           done();
         }
-      });
+      );
     });
 
     it(`Deve retornar BAD_REQUEST ao tentar fazer PUT com ID diferente do body. DbType: ${dbType.dbtype}`, (done: DoneFn) => {
@@ -152,14 +144,14 @@ describe('Testes de falha de uma aplicação CRUD simples', () => {
         detailedMessage: `Don't provide item.id in body or provide same id in both (url, body).`
       };
       // when
-      dbService.handleRequest(req).subscribe({
-        next: () => done.fail('Do not have return in Observable.next in this request'),
-        error: (erro: IHttpErrorResponse) => {
+      dbService.handleRequest(req).then(
+        () => done.fail('Do not have return in Observable.next in this request'),
+        (erro: IHttpErrorResponse) => {
           expect(erro.status).toEqual(STATUS.BAD_REQUEST);
           expect(erro.error).toEqual(responseError);
           done();
         }
-      });
+      );
     });
 
     it(`Deve retornar NOT_FOUND ao tentar fazer PUT para ID inexistente. DbType: ${dbType.dbtype}`, (done: DoneFn) => {
@@ -177,14 +169,14 @@ describe('Testes de falha de uma aplicação CRUD simples', () => {
         detailedMessage: 'Use POST instead.'
       };
       // when
-      dbService.handleRequest(req).subscribe({
-        next: () => done.fail('Do not have return in Observable.next in this request'),
-        error: (erro: IHttpErrorResponse) => {
+      dbService.handleRequest(req).then(
+        () => done.fail('Do not have return in Observable.next in this request'),
+        (erro: IHttpErrorResponse) => {
           expect(erro.status).toEqual(STATUS.NOT_FOUND);
           expect(erro.error).toEqual(responseError);
           done();
         }
-      });
+      );
     });
 
     it(`Deve retornar BAD_REQUEST ao tentar fazer DELETE sem informar o ID. DbType: ${dbType.dbtype}`, (done: DoneFn) => {
@@ -194,14 +186,14 @@ describe('Testes de falha de uma aplicação CRUD simples', () => {
         url: `http://localhost/${collectionCustomers}`,
       };
       // when
-      dbService.handleRequest(req).subscribe({
-        next: () => done.fail('Do not have return in Observable.next in this request'),
-        error: (erro: IHttpErrorResponse) => {
+      dbService.handleRequest(req).then(
+        () => done.fail('Do not have return in Observable.next in this request'),
+        (erro: IHttpErrorResponse) => {
           expect(erro.status).toEqual(STATUS.BAD_REQUEST);
           expect(erro.error).toEqual(`Missing ${collectionCustomers} id`);
           done();
         }
-      });
+      );
     });
 
     it(`Deve retornar NOT_FOUND ao tentar fazer DELETE para ID inexistente. DbType: ${dbType.dbtype}`, (done: DoneFn) => {
@@ -215,14 +207,14 @@ describe('Testes de falha de uma aplicação CRUD simples', () => {
         detailedMessage: 'Id não encontrado.'
       };
       // when
-      dbService.handleRequest(req).subscribe({
-        next: () => done.fail('Do not have return in Observable.next in this request'),
-        error: (erro: IHttpErrorResponse) => {
+      dbService.handleRequest(req).then(
+        () => done.fail('Do not have return in Observable.next in this request'),
+        (erro: IHttpErrorResponse) => {
           expect(erro.status).toEqual(STATUS.NOT_FOUND);
           expect(erro.error).toEqual(responseError);
           done();
         }
-      });
+      );
     });
 
   });

--- a/src/test/simple-crud/simple-crud-id-exception.spec.ts
+++ b/src/test/simple-crud/simple-crud-id-exception.spec.ts
@@ -55,15 +55,15 @@ describe('Testes de falha de uma aplicação CRUD com exceptions na configuraç�
         }
       };
       // when
-      dbService.handleRequest(req).subscribe({
-        next: () => done.fail('Do not have return in Observable.next in this request'),
-        error: (erro: IHttpErrorResponse) => {
+      dbService.handleRequest(req).then(
+        () => done.fail('Do not have return in Observable.next in this request'),
+        (erro: IHttpErrorResponse) => {
           // then
           expect(erro.status).toEqual(STATUS.BAD_REQUEST);
           expect(erro.error).toEqual('Id strategy is set as `provided` and id not provided.');
           done();
         }
-      });
+      );
     });
 
   });
@@ -106,14 +106,14 @@ describe('Testes de falha de uma aplicação CRUD com exceptions na configuraç�
       };
       void dbService.clearData(collectionCustomers);
       // when
-      dbService.handleRequest(req).subscribe({
+      dbService.handleRequest(req).then(
         // then
-        next: (response: IHttpResponse<ICustomer>) => {
+        (response: IHttpResponse<ICustomer>) => {
           expect(response.body).toEqual({ id: 1, name: 'Cliente sem ID informado' });
           done();
         },
-        error: (erro) => done.fail(erro)
-      });
+        (erro) => done.fail(erro)
+      );
     });
 
     it(`Deve retornar erro ao tentar criar um item com ID numérico, sem saber como incrementar`, (done: DoneFn) => {
@@ -130,16 +130,16 @@ describe('Testes de falha de uma aplicação CRUD com exceptions na configuraç�
           }
         };
         // when
-        dbService.handleRequest(req).subscribe({
-          next: () => done.fail('Do not have return in Observable.next in this request'),
-          error: (erro: IHttpErrorResponse) => {
+        dbService.handleRequest(req).then(
+          () => done.fail('Do not have return in Observable.next in this request'),
+          (erro: IHttpErrorResponse) => {
             // then
             const message = `Collection ${collectionCustomers} id type is non-numeric or unknown. Can only generate numeric ids.`;
             expect(erro.status).toEqual(STATUS.BAD_REQUEST);
             expect(erro.error).toEqual(message);
             done();
           }
-        });
+        );
       });
     });
 

--- a/src/test/simple-crud/simple-crud-transform-exception.spec.ts
+++ b/src/test/simple-crud/simple-crud-transform-exception.spec.ts
@@ -27,30 +27,22 @@ describe('Testes de falha de uma aplicação CRUD com excptions nas funções de
       delay: 0
     })
 
-    beforeAll((done: DoneFn) => {
+    beforeAll(async () => {
       if (dbType.dbtype === 'memory') {
         dbService = new MemoryDbService(backendConfig);
       } else {
         dbService = new IndexedDbService(backendConfig);
       }
       configureBackendUtils(dbService);
-      dbService.createDatabase().then(
-        () => dbService.createObjectStore(dataServiceFn).then(
-          () => done(),
-          error => done.fail(error)
-        ),
-        error => done.fail(error)
-      );
+      await dbService.createDatabase();
+      await dbService.createObjectStore(dataServiceFn);
     });
 
-    afterAll((done: DoneFn) => {
+    afterAll(async () => {
       if (dbService instanceof IndexedDbService) {
         dbService.closeDatabase();
       }
-      dbService.deleteDatabase().then(
-        () => done(),
-        (error) => done.fail(error)
-      );
+      await dbService.deleteDatabase();
     })
 
     beforeEach(() => {
@@ -72,14 +64,14 @@ describe('Testes de falha de uma aplicação CRUD com excptions nas funções de
         throw 'Erro no TransformGetById';
       });
       // when
-      dbService.handleRequest(req).subscribe({
-        next: () => done.fail('Do not have return in Observable.next in this request'),
-        error: (erro: IHttpErrorResponse) => {
+      dbService.handleRequest(req).then(
+        () => done.fail('Do not have return in Observable.next in this request'),
+        (erro: IHttpErrorResponse) => {
           expect(erro.status).toEqual(STATUS.INTERNAL_SERVER_ERROR);
           expect(erro.error).toEqual(responseError);
           done();
         }
-      });
+      );
     });
 
     it(`Deve retornar erro ao fazer GET All e ser lançado exception no TransformGetAll. DbType: ${dbType.dbtype}`, (done: DoneFn) => {
@@ -96,14 +88,14 @@ describe('Testes de falha de uma aplicação CRUD com excptions nas funções de
         throw new Error('Erro no TransformGetAll');
       });
       // when
-      dbService.handleRequest(req).subscribe({
-        next: () => done.fail('Do not have return in Observable.next in this request'),
-        error: (erro: IHttpErrorResponse) => {
+      dbService.handleRequest(req).then(
+        () => done.fail('Do not have return in Observable.next in this request'),
+        (erro: IHttpErrorResponse) => {
           expect(erro.status).toEqual(STATUS.INTERNAL_SERVER_ERROR);
           expect(erro.error).toEqual(responseError);
           done();
         }
-      });
+      );
     });
 
     it(`Deve retornar erro ao fazer POST e ser lançado exception no TransformPost. DbType: ${dbType.dbtype}`, (done: DoneFn) => {
@@ -123,14 +115,14 @@ describe('Testes de falha de uma aplicação CRUD com excptions nas funções de
         throw responseError;
       });
       // when
-      dbService.handleRequest(req).subscribe({
-        next: () => done.fail('Do not have return in Observable.next in this request'),
-        error: (erro: IHttpErrorResponse) => {
+      dbService.handleRequest(req).then(
+        () => done.fail('Do not have return in Observable.next in this request'),
+        (erro: IHttpErrorResponse) => {
           expect(erro.status).toEqual(STATUS.INTERNAL_SERVER_ERROR);
           expect(erro.error).toEqual(responseError);
           done();
         }
-      });
+      );
     });
 
     it(`Deve retornar erro ao fazer PUT e ser lançado exception no TransformPut. DbType: ${dbType.dbtype}`, (done: DoneFn) => {
@@ -156,14 +148,14 @@ describe('Testes de falha de uma aplicação CRUD com excptions nas funções de
         };
       });
       // when
-      dbService.handleRequest(req).subscribe({
-        next: () => done.fail('Do not have return in Observable.next in this request'),
-        error: (erro: IHttpErrorResponse) => {
+      dbService.handleRequest(req).then(
+        () => done.fail('Do not have return in Observable.next in this request'),
+        (erro: IHttpErrorResponse) => {
           expect(erro.status).toEqual(STATUS.INTERNAL_SERVER_ERROR);
           expect(erro.error).toEqual(responseError);
           done();
         }
-      });
+      );
     });
 
     it(`Deve retornar erro ao fazer POST para atualizar um item e ser lançado exception no TransformPut. DbType: ${dbType.dbtype}`, (done: DoneFn) => {
@@ -183,14 +175,14 @@ describe('Testes de falha de uma aplicação CRUD com excptions nas funções de
         throw 123456789;
       });
       // when
-      dbService.handleRequest(req).subscribe({
-        next: () => done.fail('Do not have return in Observable.next in this request'),
-        error: (erro: IHttpErrorResponse) => {
+      dbService.handleRequest(req).then(
+        () => done.fail('Do not have return in Observable.next in this request'),
+        (erro: IHttpErrorResponse) => {
           expect(erro.status).toEqual(STATUS.INTERNAL_SERVER_ERROR);
           expect(erro.error).toEqual(responseError);
           done();
         }
-      });
+      );
     });
 
     it(`Deve retornar erro ao fazer PUT para criar um item e ser lançado exception no TransformPost. DbType: ${dbType.dbtype}`, (done: DoneFn) => {
@@ -209,14 +201,14 @@ describe('Testes de falha de uma aplicação CRUD com excptions nas funções de
         throw 'Erro no TransformPost';
       });
       // when
-      dbService.handleRequest(req).subscribe({
-        next: () => done.fail('Do not have return in Observable.next in this request'),
-        error: (erro: IHttpErrorResponse) => {
+      dbService.handleRequest(req).then(
+        () => done.fail('Do not have return in Observable.next in this request'),
+        (erro: IHttpErrorResponse) => {
           expect(erro.status).toEqual(STATUS.INTERNAL_SERVER_ERROR);
           expect(erro.error).toEqual(responseError);
           done();
         }
-      });
+      );
     });
 
     it(`Deve retornar erro ao fazer POST e ser lançado exception no TransformGet. DbType: ${dbType.dbtype}`, (done: DoneFn) => {
@@ -235,14 +227,14 @@ describe('Testes de falha de uma aplicação CRUD com excptions nas funções de
         throw 'Erro no TransformGetById';
       });
       // when
-      dbService.handleRequest(req).subscribe({
-        next: () => done.fail('Do not have return in Observable.next in this request'),
-        error: (erro: IHttpErrorResponse) => {
+      dbService.handleRequest(req).then(
+        () => done.fail('Do not have return in Observable.next in this request'),
+        (erro: IHttpErrorResponse) => {
           expect(erro.status).toEqual(STATUS.INTERNAL_SERVER_ERROR);
           expect(erro.error).toEqual(responseError);
           done();
         }
-      });
+      );
     });
 
     it(`Deve retornar erro ao fazer POST atualizando um registro e ser lançado exception no TransformGet. DbType: ${dbType.dbtype}`, (done: DoneFn) => {
@@ -261,14 +253,14 @@ describe('Testes de falha de uma aplicação CRUD com excptions nas funções de
         throw 'Erro no TransformGetById';
       });
       // when
-      dbService.handleRequest(req).subscribe({
-        next: () => done.fail('Do not have return in Observable.next in this request'),
-        error: (erro: IHttpErrorResponse) => {
+      dbService.handleRequest(req).then(
+        () => done.fail('Do not have return in Observable.next in this request'),
+        (erro: IHttpErrorResponse) => {
           expect(erro.status).toEqual(STATUS.INTERNAL_SERVER_ERROR);
           expect(erro.error).toEqual(responseError);
           done();
         }
-      });
+      );
     });
 
     it(`Deve retornar erro ao fazer PUT e ser lançado exception no TransformGet. DbType: ${dbType.dbtype}`, (done: DoneFn) => {
@@ -287,14 +279,14 @@ describe('Testes de falha de uma aplicação CRUD com excptions nas funções de
         throw 'Erro no TransformGetById';
       });
       // when
-      dbService.handleRequest(req).subscribe({
-        next: () => done.fail('Do not have return in Observable.next in this request'),
-        error: (erro: IHttpErrorResponse) => {
+      dbService.handleRequest(req).then(
+        () => done.fail('Do not have return in Observable.next in this request'),
+        (erro: IHttpErrorResponse) => {
           expect(erro.status).toEqual(STATUS.INTERNAL_SERVER_ERROR);
           expect(erro.error).toEqual(responseError);
           done();
         }
-      });
+      );
     });
 
     it(`Deve retornar erro ao fazer PUT e ser lançado exception no TransformGet. DbType: ${dbType.dbtype}`, (done: DoneFn) => {
@@ -313,14 +305,14 @@ describe('Testes de falha de uma aplicação CRUD com excptions nas funções de
         throw 'Erro no TransformGetById';
       });
       // when
-      dbService.handleRequest(req).subscribe({
-        next: () => done.fail('Do not have return in Observable.next in this request'),
-        error: (erro: IHttpErrorResponse) => {
+      dbService.handleRequest(req).then(
+        () => done.fail('Do not have return in Observable.next in this request'),
+        (erro: IHttpErrorResponse) => {
           expect(erro.status).toEqual(STATUS.INTERNAL_SERVER_ERROR);
           expect(erro.error).toEqual(responseError);
           done();
         }
-      });
+      );
     });
 
   });

--- a/src/test/simple-crud/simple-crud.spec.ts
+++ b/src/test/simple-crud/simple-crud.spec.ts
@@ -52,7 +52,7 @@ describe('Testes para uma aplicação CRUD pura e simples', () => {
           method: 'GET',
           url: `http://localhost/${collectionCustomers}`
         };
-        dbService.handleRequest(req).subscribe(
+        dbService.handleRequest(req).then(
           (response: IHttpResponse<ICustomer[]>) => {
             expect(response.body).toEqual(customers);
             done();
@@ -75,7 +75,7 @@ describe('Testes para uma aplicação CRUD pura e simples', () => {
           url: `http://localhost/${collectionCustomers}`,
           urlWithParams: `http://localhost/${collectionCustomers}?name=23451`
         };
-        dbService.handleRequest(req).subscribe(
+        dbService.handleRequest(req).then(
           (response: IHttpResponse<ICustomer[]>) => {
             expect(response.body).toEqual(expectedCustomers);
             done();
@@ -97,7 +97,7 @@ describe('Testes para uma aplicação CRUD pura e simples', () => {
           method: 'GET',
           url: `http://localhost/${collectionCustomers}/5`,
         };
-        dbService.handleRequest(req).subscribe(
+        dbService.handleRequest(req).then(
           (response: IHttpResponse<ICustomer>) => {
             expect(response.body).toEqual(expectedCustomer);
             done();
@@ -118,7 +118,7 @@ describe('Testes para uma aplicação CRUD pura e simples', () => {
         url: `http://localhost/${collectionCustomers}`,
         body: expectedCustomer
       };
-      dbService.handleRequest(req).subscribe(
+      dbService.handleRequest(req).then(
         (responsePost: IHttpResponse<ICustomer>) => {
           expect(responsePost.body).toEqual(expectedCustomer);
           dbService.get$(collectionCustomers, '1000', undefined, collectionCustomers).subscribe(
@@ -143,7 +143,7 @@ describe('Testes para uma aplicação CRUD pura e simples', () => {
         url: `http://localhost/${collectionCustomers}`,
         body: expectedCustomer
       };
-      dbService.handleRequest(req).subscribe(
+      dbService.handleRequest(req).then(
         (responsePost: IHttpResponse<ICustomer>) => {
           expect(responsePost.body).toEqual(jasmine.objectContaining(expectedCustomer));
           expectedCustomer = Object.assign(expectedCustomer, { id: responsePost.body.id });
@@ -171,7 +171,7 @@ describe('Testes para uma aplicação CRUD pura e simples', () => {
           url: `http://localhost/${collectionCustomers}/1`,
           body: { name: 'Alterado nome cliente 1' }
         };
-        dbService.handleRequest(req).subscribe(
+        dbService.handleRequest(req).then(
           (responsePost: IHttpResponse<ICustomer>) => {
             expect(responsePost.body).toEqual(jasmine.objectContaining({ name: 'Alterado nome cliente 1' }));
             const expectedCustomer = Object.assign({}, customers[0], { name: 'Alterado nome cliente 1' });
@@ -199,7 +199,7 @@ describe('Testes para uma aplicação CRUD pura e simples', () => {
           method: 'DELETE',
           url: `http://localhost/${collectionCustomers}/5`,
         };
-        dbService.handleRequest(req).subscribe(
+        dbService.handleRequest(req).then(
           (responseDelete: IHttpResponse<ICustomer>) => {
             expect(responseDelete).toEqual(jasmine.objectContaining({ url: `http://localhost/${collectionCustomers}/5`, status: 204 }));
             dbService.get$(collectionCustomers, '5', undefined, collectionCustomers).subscribe(

--- a/src/test/transformers/trasnformers.spec.ts
+++ b/src/test/transformers/trasnformers.spec.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 import { TestCase } from 'jasmine-data-provider-ts';
 import { cloneDeep } from 'lodash';
-import { defer, of } from 'rxjs';
 import { BackendConfig } from '../../database/src/data-service/backend-config';
 import { BackendTypeArgs, IBackendService, IHttpResponse, IndexedDbService, LoadFn, MemoryDbService } from '../../public-api';
 import { configureBackendUtils } from '../utils/configure-backend-utils';
@@ -34,7 +33,7 @@ const transformePut = (product: IProduct, body: Partial<IProduct>): IProduct => 
   return body as IProduct;
 }
 
-describe('Testes para as funções de trasnformação', () => {
+describe('Testes para as funções de transformação', () => {
 
   TestCase<BackendTypeArgs>([{ dbtype: 'memory' }, { dbtype: 'indexdb' }], (dbType) => {
     let dbService: MemoryDbService | IndexedDbService;
@@ -44,6 +43,7 @@ describe('Testes para as funções de trasnformação', () => {
       returnItemIn201: true,
       put204: false,
       strategyId: 'provided',
+      jsonParseWithDate: false,
       delay: 0
     })
 
@@ -153,9 +153,9 @@ describe('Testes para as funções de trasnformação', () => {
       );
     });
 
-    it('Deve aplicar a transformação no GetById com Observable', (done: DoneFn) => {
+    it('Deve aplicar a transformação no GetById com Promise', (done: DoneFn) => {
       // given
-      const transformeGet$ = (product: IProduct) => defer(() => of(transformeGet(product)));
+      const transformeGet$ = (product: IProduct) => new Promise(resolve => resolve(transformeGet(product)));
       dbService.addTransformGetByIdMap(collectionProducts, transformeGet$);
       const expectedProduct = transformeGet(transformePost(cloneDeep(products[0])));
       // when
@@ -169,9 +169,9 @@ describe('Testes para as funções de trasnformação', () => {
       );
     });
 
-    it('Deve aplicar a transformação no Post com Observable', (done: DoneFn) => {
+    it('Deve aplicar a transformação no Post com Promise', (done: DoneFn) => {
       // given
-      const transformePost$ = (product: IProduct) => defer(() => of(transformePost(product)));
+      const transformePost$ = (product: IProduct) => new Promise(resolve => resolve(transformePost(product)));
       dbService.addTransformPostMap(collectionProducts, transformePost$);
       const postProduct: IProduct = {
         id: '987654321',
@@ -191,9 +191,9 @@ describe('Testes para as funções de trasnformação', () => {
       );
     });
 
-    it('Deve aplicar a transformação no Put com Observable', (done: DoneFn) => {
+    it('Deve aplicar a transformação no Put com Promise', (done: DoneFn) => {
       // given
-      const transformePut$ = (product: IProduct, body: Partial<IProduct>) => defer(() => of(transformePut(product, body)));
+      const transformePut$ = (product: IProduct, body: Partial<IProduct>) => new Promise(resolve => resolve(transformePut(product, body)));
       dbService.addTransformPutMap(collectionProducts, transformePut$);
       const expectedProduct = transformePut(null, transformePost(cloneDeep(products[1])));
       expectedProduct.active = false;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,12 +11,12 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "importHelpers": true,
-    "target": "ES2022",
+    "target": "es2022",
     "typeRoots": [
       "node_modules/@types"
     ],
     "lib": [
-      "es2018",
+      "es2022",
       "dom"
     ],
     "useDefineForClassFields": false


### PR DESCRIPTION
- Adicionado suporte de retorno como Promise por padrão para todos os métodos get$, post$, put$ e delete$. 
- Para compatibilidade será mantido nesta versão o retorno como Observable, porém, caso seja passado `false` no último parametro o retorno já será uma Promise
- Alterado para quando for despachado para o servidor real utilizar a api `fetch`ao invés da api `XMLHttpRequest` 
- Alterado para compatibilidade com angular da versão 13 até a 17.